### PR TITLE
fix: Refactor ToggleButton icon style in Main.xaml

### DIFF
--- a/yt-dlp-gui/Views/Main.xaml
+++ b/yt-dlp-gui/Views/Main.xaml
@@ -140,20 +140,19 @@
                         </controls:TextEditor.ContextMenu>
                     </controls:TextEditor>
                     <ToggleButton Grid.Column="1" Margin="4,2,0,2" Padding="6,0" IsChecked="{Binding IsMonitor}">
-                        <controls:Icons Size="14">
-                            <controls:Icons.Style>
-                                <Style TargetType="controls:Icons">
-                                    <Setter Property="Kind" Value="Monitor"/>
-                                    <Setter Property="Foreground" Value="#FFEBEBEB"/>
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding IsMonitor}" Value="True">
-                                            <Setter Property="Kind" Value="MonitorEye"/>
-                                            <Setter Property="Foreground" Value="#FF50A4FA"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </controls:Icons.Style>
-                        </controls:Icons>
+                        <ToggleButton.Resources>
+                            <Style x:Key="MonitorIconStyle" TargetType="controls:Icons">
+                                <Setter Property="Kind" Value="Monitor"/>
+                                <Setter Property="Foreground" Value="#FFEBEBEB"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource AncestorType=ToggleButton}}" Value="True">
+                                        <Setter Property="Kind" Value="MonitorEye"/>
+                                        <Setter Property="Foreground" Value="#FF50A4FA"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ToggleButton.Resources>
+                        <controls:Icons Size="14" Style="{StaticResource MonitorIconStyle}"/>
                     </ToggleButton>
                     <Button Grid.Column="2" IsEnabled="{Binding Enable.Analyze}" Margin="2" Click="Button_Analyze">
                         <StackPanel Orientation="Horizontal" Margin="4,0">


### PR DESCRIPTION
Moved the Style for the controls:Icons element within the URL monitoring ToggleButton into ToggleButton.Resources to resolve an MC3088 XAML parsing error ("Property elements cannot be in the middle of an element's content").

The DataTrigger binding within the style was updated to correctly reference the IsChecked property of the parent ToggleButton.