### PR TITLE
fix: Replace Main.xaml with your provided version

### DIFF
--- a/yt-dlp-gui/Libs/YamlDescription.cs
+++ b/yt-dlp-gui/Libs/YamlDescription.cs
@@ -5,7 +5,6 @@ using YamlDotNet.Core.Events; // Required for MappingStart, MappingEnd, Scalar, 
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.ObjectFactories; // Although ObjectDeserializer and ObjectSerializer are used, ObjectFactories might not be strictly needed for this specific converter's WriteYaml.
 
-
 namespace yt_dlp_gui.Libs
 {
     public class YamlDescription : IYamlTypeConverter

--- a/yt-dlp-gui/Views/Main.xaml
+++ b/yt-dlp-gui/Views/Main.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="yt_dlp_gui.Views.Main"
+<Window x:Class="yt_dlp_gui.Views.Main"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:app="clr-namespace:yt_dlp_gui"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -6,7 +6,9 @@
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:controls="clr-namespace:yt_dlp_gui.Controls"
-        xmlns:m="clr-namespace:yt_dlp_gui.Models" xmlns:local="clr-namespace:yt_dlp_gui.Views" xmlns:b="clr-namespace:yt_dlp_gui.Controls.Behaviors"
+        xmlns:m="clr-namespace:yt_dlp_gui.Models"
+        xmlns:local="clr-namespace:yt_dlp_gui.Views"
+        xmlns:b="clr-namespace:yt_dlp_gui.Controls.Behaviors"
         xmlns:converters="clr-namespace:yt_dlp_gui.Converters"
         mc:Ignorable="d" Style="{DynamicResource WindowStyle}"
         Title="{Binding Source={x:Static app:App.Lang}, Path=AppName}" Width="600" Height="380"
@@ -19,8 +21,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <!-- Existing merged dictionaries for themes etc. should be here if any were present before -->
-                <!-- If themes were managed by ThemeManager and MergedDictionaries was empty, it can stay empty -->
+                <!-- Theme dictionaries are added here by ThemeManager -->
             </ResourceDictionary.MergedDictionaries>
 
             <converters:NullOrEmptyToVisibilityConverter x:Key="NullOrEmptyToVisibilityConverter"/>
@@ -67,809 +68,781 @@
 
         </ResourceDictionary>
     </Window.Resources>
-    <TabControl Grid.Row="3" TabStripPlacement="Top" Margin="6,4">
-        <TabItem Header="{Binding Source={x:Static app:App.Lang}, Path=Main.Main}">
-            <Grid Margin="4" Grid.IsSharedSizeScope="True">
-                <!-- Add Toggle Button Here -->
-                <Button Content="Toggle Theme" Click="ToggleThemeButton_Click" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,5,0,0" Padding="5,2"/>
-                <Grid.Resources>
-                    <Style TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
-                        <Setter Property="Margin" Value="0,2"/>
-                    </Style>
-                    <!-- MonitorIconStyle should not be here -->
-                </Grid.Resources>
-                <Grid.RowDefinitions>
-                    <!-- 0 -->
-                    <RowDefinition Height="Auto"/> <!-- Row for ToggleButton -->
-                    <!-- 0 -->
-                    <RowDefinition Height="Auto"/>
-                    <!-- 1 -->
-                    <RowDefinition Height="Auto"/>
-                    <!-- 2 -->
-                    <RowDefinition Height="*"/>
-                    <!-- 3 -->
-                    <RowDefinition Height="Auto"/>
-                    <!-- 4 -->
-                    <RowDefinition Height="Auto"/>
-                    <!-- 5 -->
-                    <RowDefinition Height="Auto"/>
-                    <!-- 6 -->
-                    <RowDefinition Height="Auto"/>
-                    <!-- 7 -->
-                    <RowDefinition Height="Auto"/>
-                    <!-- 8 -->
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="5*"/>
-                    <ColumnDefinition Width="2"/>
-                    <ColumnDefinition Width="3*"/>
-                </Grid.ColumnDefinitions>
-                <!-- Url-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <Grid Grid.Row="1" Grid.ColumnSpan="3"> <!-- Changed Grid.Row from 0 to 1 -->
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto" SharedSizeGroup="Button"/>
-                    </Grid.ColumnDefinitions>
-                    <controls:TextEditor Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.Url}" Margin="0,2" IsEnabled="{Binding Enable.Url}"
-                                 WordWrap="True"
-                                 Text="{Binding Url}" Syntax="url" EnableHyperlinks="False">
-                        <controls:TextEditor.ContextMenu>
-                            <ContextMenu>
-                                <MenuItem Command="ApplicationCommands.Cut">
-                                    <MenuItem.Icon>
-                                        <controls:Icons Size="14" Kind="ContentCut"/>
-                                    </MenuItem.Icon>
-                                </MenuItem>
-                                <MenuItem Command="ApplicationCommands.Copy">
-                                    <MenuItem.Icon>
-                                        <controls:Icons Size="14" Kind="ContentCopy"/>
-                                    </MenuItem.Icon>
-                                </MenuItem>
-                                <MenuItem Command="ApplicationCommands.Paste">
-                                    <MenuItem.Icon>
-                                        <controls:Icons Size="14" Kind="ContentPaste"/>
-                                    </MenuItem.Icon>
-                                </MenuItem>
-                                <MenuItem Command="ApplicationCommands.Delete">
-                                    <MenuItem.Icon>
-                                        <controls:Icons Size="14" Kind="Eraser"/>
-                                    </MenuItem.Icon>
-                                </MenuItem>
-                            </ContextMenu>
-                        </controls:TextEditor.ContextMenu>
-                    </controls:TextEditor>
-                    <ToggleButton Grid.Column="1" Margin="4,2,0,2" Padding="6,0" IsChecked="{Binding IsMonitor}">
-                        <ToggleButton.Resources>
-                            <Style x:Key="MonitorIconStyle" TargetType="controls:Icons">
-                                <Setter Property="Kind" Value="Monitor"/>
-                                <Setter Property="Foreground" Value="#FFEBEBEB"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource AncestorType=ToggleButton}}" Value="True">
-                                        <Setter Property="Kind" Value="MonitorEye"/>
-                                        <Setter Property="Foreground" Value="#FF50A4FA"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </ToggleButton.Resources>
-                        <controls:Icons Size="14" Style="{StaticResource MonitorIconStyle}"/>
-                    </ToggleButton>
-                    <Button Grid.Column="2" IsEnabled="{Binding Enable.Analyze}" Margin="2" Click="Button_Analyze">
-                        <StackPanel Orientation="Horizontal" Margin="4,0">
-                            <controls:Icons Size="14" Kind="Magnify" IsLoading="{Binding IsAnalyze}"/>
-                            <TextBlock Margin="2,0,0,0" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Analyze}"/>
-                        </StackPanel>
-                    </Button>
-                </Grid>
-                <!-- Thumbnail -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <Grid Grid.Row="2" Grid.Column="2" Grid.RowSpan="3"> <!-- Changed Grid.Row from 1 to 2 -->
+    <Grid x:Name="MainGrid"> <!-- Added x:Name for scale transform -->
+        <TabControl TabStripPlacement="Top" Margin="6,4">
+            <TabItem Header="{Binding Source={x:Static app:App.Lang}, Path=Main.Main}">
+                <Grid Margin="4" Grid.IsSharedSizeScope="True">
+                    <Grid.Resources>
+                        <Style TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
+                            <Setter Property="Margin" Value="0,2"/>
+                        </Style>
+                        <Style x:Key="MonitorIconStyle" TargetType="controls:Icons">
+                            <Setter Property="Kind" Value="Monitor"/>
+                            <Setter Property="Foreground" Value="#FFEBEBEB"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource AncestorType=ToggleButton}}" Value="True">
+                                    <Setter Property="Kind" Value="MonitorEye"/>
+                                    <Setter Property="Foreground" Value="#FF50A4FA"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Grid.Resources>
                     <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/> <!-- Row for ToggleButton -->
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                         <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <StackPanel>
-                        <Border BorderBrush="{StaticResource ControlDefaultBorderBrush}"
-                                BorderThickness="1" Margin="2"
-                                Height="{Binding ImageHeight}" VerticalAlignment="Top" >
-                            <i:Interaction.Behaviors>
-                                <controls:ActualSize ActualWidth="{Binding ImageWidth}"/>
-                            </i:Interaction.Behaviors>
-                            <Grid>
-                                <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Thumbnail}" Foreground="Gray" IsHitTestVisible="False" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                <Image VerticalAlignment="Center" Stretch="UniformToFill"
-                                       Source="{Binding Thumbnail, TargetNullValue={x:Null}}">
-                                    <Image.CacheMode>
-                                        <BitmapCache EnableClearType="False" RenderAtScale="1" SnapsToDevicePixels="False"/>
-                                    </Image.CacheMode>
-                                </Image>
-                                <TextBlock Background="#60000000" Foreground="White" Padding="4,0"
-                                   IsHitTestVisible="False"
-                                   HorizontalAlignment="Right" VerticalAlignment="Bottom"
-                                   controls:Duration.Secs="{Binding Video.duration}">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Thumbnail}" Value="">
-                                                    <Setter Property="Visibility" Value="Hidden"/>
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Thumbnail}" Value="{x:Null}">
-                                                    <Setter Property="Visibility" Value="Hidden"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
-                                <TextBlock HorizontalAlignment="Right" VerticalAlignment="Bottom" Padding="4,0" Background="Red" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Live}">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Video.is_live}" Value="False">
-                                                    <Setter Property="Visibility" Value="Collapsed"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
-                            </Grid>
-                            <Border.ContextMenu>
-                                <ContextMenu>
-                                    <MenuItem Command="ApplicationCommands.SaveAs">
-                                        <MenuItem.Icon>
-                                            <controls:Icons Size="14" Kind="ContentSave"/>
-                                        </MenuItem.Icon>
-                                    </MenuItem>
-                                </ContextMenu>
-                            </Border.ContextMenu>
-                        </Border>
-                        <CheckBox Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.DownloadThumb}" VerticalAlignment="Center"
-                          IsEnabled="{Binding Enable.SaveThumbnail}"
-                          Margin="2,0" IsChecked="{Binding SaveThumbnail}"
-                          HorizontalAlignment="Left"/>
-                    </StackPanel>
-                    <!-- Download Infomation -->
-                    <ItemsControl Grid.Row="2" VerticalAlignment="Bottom" Margin="4" ItemsSource="{Binding DNStatus_InfosView}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <StackPanel/>
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" SharedSizeGroup="InfoLabel"/>
-                                        <ColumnDefinition/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock FontSize="10" Text="{Binding Key, Converter={StaticResource languageConverter}}"/>
-                                    <TextBlock FontSize="10" Grid.Column="1" Text="{Binding Value}" HorizontalAlignment="Right"/>
-                                </Grid>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-                </Grid>
-                <!-- Title-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <controls:TextEditor Grid.Row="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.Title}" Text="{Binding Video.title}" <!-- Changed Grid.Row from 1 to 2 -->
-                             Margin="0,2" IsReadOnly="True" WordWrap="True"
-                             EnableHyperlinks="False">
-                    <controls:TextEditor.ContextMenu>
-                        <ContextMenu>
-                            <MenuItem Command="ApplicationCommands.Copy">
-                                <MenuItem.Icon>
-                                    <controls:Icons Size="14" Kind="ContentCopy"/>
-                                </MenuItem.Icon>
-                            </MenuItem>
-                        </ContextMenu>
-                    </controls:TextEditor.ContextMenu>
-                </controls:TextEditor>
-                <!-- Desc-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <controls:TextEditor Grid.Row="3" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.Title}" <!-- Changed Grid.Row from 2 to 3 -->
-                             Margin="0,2" Syntax="desc"
-                             Multiline="True" EnableHyperlinks="True" IsReadOnly="True"
-                             Text="{Binding Video.description}">
-                    <controls:TextEditor.ContextMenu>
-                        <ContextMenu>
-                            <MenuItem Command="ApplicationCommands.Copy">
-                                <MenuItem.Icon>
-                                    <controls:Icons Size="14" Kind="ContentCopy"/>
-                                </MenuItem.Icon>
-                            </MenuItem>
-                        </ContextMenu>
-                    </controls:TextEditor.ContextMenu>
-                </controls:TextEditor>
-                <!-- -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <Grid Grid.Row="4" VerticalAlignment="Top"> <!-- Changed Grid.Row from 3 to 4 -->
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
-                    <!-- Chapters -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                    <Grid Grid.Row="1">
-                        <Grid.Style>
-                            <Style TargetType="Grid">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding hasChapter}" Value="False">
-                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Grid.Style>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
-                            <ColumnDefinition/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Chapters}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
-                        <ComboBox x:Name="cc" Grid.Column="1"
-                                  IsEnabled="{Binding Enable.SelectChapters}"
-                                  HorizontalContentAlignment="Stretch"
-                                  SelectedValue="{Binding selectedChapter}" 
-                                  ItemsSource="{Binding ChaptersView}">
-                            <ComboBox.ItemContainerStyle>
-                                <Style TargetType="ComboBoxItem">
-                                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                                </Style>
-                            </ComboBox.ItemContainerStyle>
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid>
-                                        <Grid.Resources>
-                                            <Style TargetType="TextBlock">
-                                                <Setter Property="Margin" Value="2,0"/>
-                                            </Style>
-                                        </Grid.Resources>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="Auto" SharedSizeGroup="C1" />
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock Grid.Column="0" HorizontalAlignment="Left" Text="{Binding title}"/>
-                                        <StackPanel Grid.Column="1" Orientation="Horizontal">
-                                            <StackPanel.Style>
-                                                <Style TargetType="StackPanel">
-                                                    <Setter Property="Visibility" Value="Hidden"/>
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding type}" Value="Segment">
-                                                            <Setter Property="Visibility" Value="Visible"/>
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </StackPanel.Style>
-                                            <TextBlock controls:Duration.Secs="{Binding start_time}"/>
-                                            <TextBlock Text="~"/>
-                                            <TextBlock controls:Duration.Secs="{Binding end_time}"/>
-                                        </StackPanel>
-                                    </Grid>
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
-                    </Grid>
-                    <!-- Video-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                    <Grid Grid.Row="2">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
-                            <ColumnDefinition/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Video}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
-                        <ComboBox Grid.Column="1"
-                                          x:Name="cv" IsEnabled="{Binding Enable.FormatVideo}"
-                                          Template="{StaticResource ComboBoxTemplateForVideo}"
-                                          SelectedValue="{Binding selectedVideo}"
-                                          ItemsSource="{Binding FormatsVideo}">
-                            <ComboBox.ItemContainerStyle>
-                                <Style TargetType="ComboBoxItem">
-                                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                                </Style>
-                            </ComboBox.ItemContainerStyle>
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid>
-                                        <Grid.Resources>
-                                            <Style TargetType="TextBlock">
-                                                <Setter Property="Margin" Value="2,0"/>
-                                                <Setter Property="HorizontalAlignment" Value="Center"/>
-                                            </Style>
-                                        </Grid.Resources>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition SharedSizeGroup="S0" />
-                                            <ColumnDefinition SharedSizeGroup="S1" />
-                                            <ColumnDefinition SharedSizeGroup="S2" />
-                                            <ColumnDefinition SharedSizeGroup="S3" />
-                                            <ColumnDefinition SharedSizeGroup="S4" />
-                                            <ColumnDefinition SharedSizeGroup="S5" />
-                                            <ColumnDefinition SharedSizeGroup="S6" />
-                                        </Grid.ColumnDefinitions>
-                                        <controls:Icons Size="14">
-                                            <controls:Icons.Style>
-                                                <Style TargetType="controls:Icons">
-                                                    <Setter Property="Kind" Value="None"/>
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding type}" Value="package">
-                                                            <Setter Property="Kind" Value="LinkVariant"/>
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </controls:Icons.Style>
-                                        </controls:Icons>
-                                        <TextBlock FontSize="10" Grid.Column="1" HorizontalAlignment="Left" Text="{Binding resolution}"/>
-                                        <TextBlock FontSize="10" Grid.Column="2" HorizontalAlignment="Center" Text="{Binding dynamic_range}"/>
-                                        <TextBlock FontSize="10" Grid.Column="3" HorizontalAlignment="Center" Text="{Binding fps}"/>
-                                        <TextBlock FontSize="10" Grid.Column="4" Text="{Binding video_ext}"/>
-                                        <TextBlock FontSize="10" Grid.Column="5" Text="{Binding vcodec}"/>
-                                        <TextBlock FontSize="10" Grid.Column="6" HorizontalAlignment="Right" controls:Filesize.Bytes="{Binding filesize}"/>
-                                    </Grid>
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                            <d:ComboBoxItem IsSelected="True">1920×1080 vp9 30fps 76.58MB</d:ComboBoxItem>
-                        </ComboBox>
-                        <ProgressBar Grid.Column="1" Value="{Binding VideoPersent}" Margin="1,3" IsHitTestVisible="False"
-                                             BorderThickness="0" Background="Transparent" Foreground="#3000ff00">
-                            <ProgressBar.Style>
-                                <Style TargetType="ProgressBar">
-                                    <Setter Property="Visibility" Value="Hidden"/>
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding IsDownload}" Value="True">
-                                            <Setter Property="Visibility" Value="Visible"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </ProgressBar.Style>
-                        </ProgressBar>
-                        <Button Grid.Column="2" Margin="2,2,0,2" Padding="3,0" 
-                                IsEnabled="{Binding Enable.SaveVideo}" Click="Button_SaveVideo" Cursor="Hand">
-                            <controls:Icons Size="14" Kind="Download"/>
-                        </Button>
-                    </Grid>
-                    <!-- Audio-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                    <Grid Grid.Row="3">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
-                            <ColumnDefinition/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Audio}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
-                        <ComboBox x:Name="ca" Grid.Column="1"
-                                          Template="{StaticResource ComboBoxTemplateForAudio}"
-                                          SelectedValue="{Binding selectedAudio}" IsEnabled="{Binding Enable.FormatAudio}"
-                                          ItemsSource="{Binding FormatsAudio}">
-                            <ComboBox.ItemContainerStyle>
-                                <Style TargetType="ComboBoxItem">
-                                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                                    <Setter Property="IsEnabled" Value="True"/>
-                                    <Style.Triggers>
-                                        <MultiDataTrigger>
-                                            <MultiDataTrigger.Conditions>
-                                                <Condition Binding="{Binding DataContext.selectedVideo.type ,RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ComboBox}}" Value="video"/>
-                                                <Condition Binding="{Binding type}" Value="package"/>
-                                            </MultiDataTrigger.Conditions>
-                                            <Setter Property="IsEnabled" Value="False"/>
-                                        </MultiDataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </ComboBox.ItemContainerStyle>
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid>
-                                        <Grid.Resources>
-                                            <Style TargetType="TextBlock">
-                                                <Setter Property="Margin" Value="2,0"/>
-                                                <Setter Property="HorizontalAlignment" Value="Center"/>
-                                            </Style>
-                                        </Grid.Resources>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition SharedSizeGroup="S0" />
-                                            <ColumnDefinition SharedSizeGroup="S1" />
-                                            <ColumnDefinition SharedSizeGroup="S2" />
-                                            <ColumnDefinition SharedSizeGroup="S3" />
-                                            <ColumnDefinition SharedSizeGroup="S4" />
-                                            <ColumnDefinition SharedSizeGroup="S5" />
-                                            <ColumnDefinition SharedSizeGroup="S6" />
-                                        </Grid.ColumnDefinitions>
-                                        <controls:Icons Size="14">
-                                            <controls:Icons.Style>
-                                                <Style TargetType="controls:Icons">
-                                                    <Setter Property="Kind" Value="None"/>
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding type}" Value="package">
-                                                            <Setter Property="Kind" Value="LinkVariant"/>
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </controls:Icons.Style>
-                                        </controls:Icons>
-                                        <TextBlock FontSize="10" Grid.Column="1" HorizontalAlignment="Left" Text="{Binding asr, StringFormat={}{0}Hz, TargetNullValue=Unknow}"/>
-                                        <TextBlock FontSize="10" Grid.Column="4" Text="{Binding audio_ext}"/>
-                                        <TextBlock FontSize="10" Grid.Column="5" Text="{Binding acodec}"/>
-                                        <TextBlock FontSize="10" Grid.Column="6" HorizontalAlignment="Right" controls:Filesize.Bytes="{Binding filesize}"/>
-                                    </Grid>
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                            <d:ComboBoxItem IsSelected="True">1920×1080 vp9 30fps 76.58MB</d:ComboBoxItem>
-                        </ComboBox>
-                        <ProgressBar Grid.Column="1" Value="{Binding AudioPersent}" Margin="1,3" IsHitTestVisible="False"
-                                     BorderThickness="0" Background="Transparent" Foreground="#3000ff00">
-                            <ProgressBar.Style>
-                                <Style TargetType="ProgressBar">
-                                    <Setter Property="Visibility" Value="Hidden"/>
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding IsDownload}" Value="True">
-                                            <Setter Property="Visibility" Value="Visible"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </ProgressBar.Style>
-                        </ProgressBar>
-                        <Button Grid.Column="2" Margin="2,2,0,2" Padding="3,0" 
-                                IsEnabled="{Binding Enable.SaveAudio}" Click="Button_SaveAudio" Cursor="Hand">
-                            <controls:Icons Size="14" Kind="Download"/>
-                        </Button>
-                    </Grid>
-                    <!-- Subtitle-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                    <Grid Grid.Row="4">
-                        <Grid.Style>
-                            <Style TargetType="Grid">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding hasSubtitle}" Value="False">
-                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Grid.Style>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
-                            <ColumnDefinition/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Subtitle}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
-                        <ComboBox x:Name="cs" Grid.Column="1"
-                                  IsEnabled="{Binding Enable.SelectSubtitle}"
-                                  SelectedValue="{Binding selectedSub}" 
-                                  DisplayMemberPath="name"
-                                  ItemsSource="{Binding SubtitlesView}"/>
-                        <ProgressBar Grid.Column="1" Value="{Binding SubtitlePersent}" Margin="1,3" IsHitTestVisible="False"
-                                     BorderThickness="0" Background="Transparent" Foreground="#3000ff00">
-                            <ProgressBar.Style>
-                                <Style TargetType="ProgressBar">
-                                    <Setter Property="Visibility" Value="Hidden"/>
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding IsDownload}" Value="True">
-                                            <Setter Property="Visibility" Value="Visible"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </ProgressBar.Style>
-                        </ProgressBar>
-                        <Button Grid.Column="2" Margin="2,2,0,2" Padding="3,0" 
-                                IsEnabled="{Binding Enable.SaveSubtitle}" Click="Button_Subtitle" Cursor="Hand">
-                            <controls:Icons Size="14" Kind="Download"/>
-                        </Button>
-                    </Grid>
-                </Grid>
-                <!-- -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <Grid Grid.Row="5" Grid.ColumnSpan="3"> <!-- Changed Grid.Row from 4 to 5 -->
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition/>
-                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="5*"/>
+                        <ColumnDefinition Width="2"/>
+                        <ColumnDefinition Width="3*"/>
                     </Grid.ColumnDefinitions>
-                    <Grid>
+
+                    <Button Content="Toggle Theme (Test)" Click="ToggleThemeButton_Click" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,0,0,5" Padding="5,2" Grid.Row="0" Grid.Column="0"/>
+
+                    <!-- Url -->
+                    <Grid Grid.Row="1" Grid.ColumnSpan="3">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition/>
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="Auto" SharedSizeGroup="Button"/>
                         </Grid.ColumnDefinitions>
-                        <controls:TextEditor Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.SaveAs}" Text="{Binding TargetDisplay}" 
-                                             IsReadOnly="True" WordWrap="True" Margin="0,2"/>
-                        <Button Grid.Column="1" Margin="2" Cursor="Hand" Click="Button_ExplorerTarget">
+                        <controls:TextEditor Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.Url}" Margin="0,2" IsEnabled="{Binding Enable.Url}"
+                                     WordWrap="True"
+                                     Text="{Binding Url}" Syntax="url" EnableHyperlinks="False">
+                            <controls:TextEditor.ContextMenu>
+                                <ContextMenu>
+                                    <MenuItem Command="ApplicationCommands.Cut">
+                                        <MenuItem.Icon>
+                                            <controls:Icons Size="14" Kind="ContentCut"/>
+                                        </MenuItem.Icon>
+                                    </MenuItem>
+                                    <MenuItem Command="ApplicationCommands.Copy">
+                                        <MenuItem.Icon>
+                                            <controls:Icons Size="14" Kind="ContentCopy"/>
+                                        </MenuItem.Icon>
+                                    </MenuItem>
+                                    <MenuItem Command="ApplicationCommands.Paste">
+                                        <MenuItem.Icon>
+                                            <controls:Icons Size="14" Kind="ContentPaste"/>
+                                        </MenuItem.Icon>
+                                    </MenuItem>
+                                    <MenuItem Command="ApplicationCommands.Delete">
+                                        <MenuItem.Icon>
+                                            <controls:Icons Size="14" Kind="Eraser"/>
+                                        </MenuItem.Icon>
+                                    </MenuItem>
+                                </ContextMenu>
+                            </controls:TextEditor.ContextMenu>
+                        </controls:TextEditor>
+                        <ToggleButton Grid.Column="1" Margin="4,2,0,2" Padding="6,0" IsChecked="{Binding IsMonitor}">
+                            <controls:Icons Size="14" Style="{StaticResource MonitorIconStyle}"/>
+                        </ToggleButton>
+                        <Button Grid.Column="2" IsEnabled="{Binding Enable.Analyze}" Margin="2" Click="Button_Analyze">
                             <StackPanel Orientation="Horizontal" Margin="4,0">
-                                <controls:Icons Size="14" Kind="FolderMoveOutline"/>
+                                <controls:Icons Size="14" Kind="Magnify" IsLoading="{Binding IsAnalyze}"/>
+                                <TextBlock Margin="2,0,0,0" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Analyze}"/>
                             </StackPanel>
                         </Button>
-                        <Button Grid.Column="2" IsEnabled="{Binding Enable.Browser}" 
-                                Margin="4,2,2,2" Click="Button_Browser" Cursor="Hand">
-                            <TextBlock Margin="2,0,0,0" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Browse}"/>
+                    </Grid>
+                    <!-- Thumbnail -->
+                    <Grid Grid.Row="2" Grid.Column="2" Grid.RowSpan="3">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <StackPanel>
+                            <Border BorderBrush="{StaticResource ControlDefaultBorderBrush}"
+                                    BorderThickness="1" Margin="2"
+                                    Height="{Binding ImageHeight}" VerticalAlignment="Top" >
+                                <i:Interaction.Behaviors>
+                                    <controls:ActualSize ActualWidth="{Binding ImageWidth}"/>
+                                </i:Interaction.Behaviors>
+                                <Grid>
+                                    <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Thumbnail}" Foreground="Gray" IsHitTestVisible="False" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                    <Image VerticalAlignment="Center" Stretch="UniformToFill"
+                                           Source="{Binding Thumbnail, TargetNullValue={x:Null}}">
+                                        <Image.CacheMode>
+                                            <BitmapCache EnableClearType="False" RenderAtScale="1" SnapsToDevicePixels="False"/>
+                                        </Image.CacheMode>
+                                    </Image>
+                                    <TextBlock Background="#60000000" Foreground="White" Padding="4,0"
+                                       IsHitTestVisible="False"
+                                       HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                                       controls:Duration.Secs="{Binding Video.duration}">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Thumbnail}" Value="">
+                                                        <Setter Property="Visibility" Value="Hidden"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Thumbnail}" Value="{x:Null}">
+                                                        <Setter Property="Visibility" Value="Hidden"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                    <TextBlock HorizontalAlignment="Right" VerticalAlignment="Bottom" Padding="4,0" Background="Red" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Live}">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Video.is_live}" Value="False">
+                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </Grid>
+                                <Border.ContextMenu>
+                                    <ContextMenu>
+                                        <MenuItem Command="ApplicationCommands.SaveAs">
+                                            <MenuItem.Icon>
+                                                <controls:Icons Size="14" Kind="ContentSave"/>
+                                            </MenuItem.Icon>
+                                        </MenuItem>
+                                    </ContextMenu>
+                                </Border.ContextMenu>
+                            </Border>
+                            <CheckBox Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.DownloadThumb}" VerticalAlignment="Center"
+                              IsEnabled="{Binding Enable.SaveThumbnail}"
+                              Margin="2,0" IsChecked="{Binding SaveThumbnail}"
+                              HorizontalAlignment="Left"/>
+                        </StackPanel>
+                        <!-- Download Infomation -->
+                        <ItemsControl Grid.Row="2" VerticalAlignment="Bottom" Margin="4" ItemsSource="{Binding DNStatus_InfosView}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel/>
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" SharedSizeGroup="InfoLabel"/>
+                                            <ColumnDefinition/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock FontSize="10" Text="{Binding Key, Converter={StaticResource languageConverter}}"/>
+                                        <TextBlock FontSize="10" Grid.Column="1" Text="{Binding Value}" HorizontalAlignment="Right"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </Grid>
+                    <!-- Title -->
+                    <controls:TextEditor Grid.Row="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.Title}" Text="{Binding Video.title}"
+                                 Margin="0,2" IsReadOnly="True" WordWrap="True"
+                                 EnableHyperlinks="False">
+                        <controls:TextEditor.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem Command="ApplicationCommands.Copy">
+                                    <MenuItem.Icon>
+                                        <controls:Icons Size="14" Kind="ContentCopy"/>
+                                    </MenuItem.Icon>
+                                </MenuItem>
+                            </ContextMenu>
+                        </controls:TextEditor.ContextMenu>
+                    </controls:TextEditor>
+                    <!-- Desc -->
+                    <controls:TextEditor Grid.Row="3" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.Title}"
+                                 Margin="0,2" Syntax="desc"
+                                 Multiline="True" EnableHyperlinks="True" IsReadOnly="True"
+                                 Text="{Binding Video.description}">
+                        <controls:TextEditor.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem Command="ApplicationCommands.Copy">
+                                    <MenuItem.Icon>
+                                        <controls:Icons Size="14" Kind="ContentCopy"/>
+                                    </MenuItem.Icon>
+                                </MenuItem>
+                            </ContextMenu>
+                        </controls:TextEditor.ContextMenu>
+                    </controls:TextEditor>
+                    <Grid Grid.Row="4" VerticalAlignment="Top">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <!-- Chapters -->
+                        <Grid Grid.Row="1">
+                            <Grid.Style>
+                                <Style TargetType="Grid">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding hasChapter}" Value="False">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Grid.Style>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
+                                <ColumnDefinition/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Chapters}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
+                            <ComboBox x:Name="cc" Grid.Column="1"
+                                      IsEnabled="{Binding Enable.SelectChapters}"
+                                      HorizontalContentAlignment="Stretch"
+                                      SelectedValue="{Binding selectedChapter}"
+                                      ItemsSource="{Binding ChaptersView}">
+                                <ComboBox.ItemContainerStyle>
+                                    <Style TargetType="ComboBoxItem">
+                                        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                    </Style>
+                                </ComboBox.ItemContainerStyle>
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid>
+                                            <Grid.Resources>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Margin" Value="2,0"/>
+                                                </Style>
+                                            </Grid.Resources>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" SharedSizeGroup="C1" />
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Grid.Column="0" HorizontalAlignment="Left" Text="{Binding title}"/>
+                                            <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                                <StackPanel.Style>
+                                                    <Style TargetType="StackPanel">
+                                                        <Setter Property="Visibility" Value="Hidden"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding type}" Value="Segment">
+                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </StackPanel.Style>
+                                                <TextBlock controls:Duration.Secs="{Binding start_time}"/>
+                                                <TextBlock Text="~"/>
+                                                <TextBlock controls:Duration.Secs="{Binding end_time}"/>
+                                            </StackPanel>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </Grid>
+                        <!-- Video -->
+                        <Grid Grid.Row="2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
+                                <ColumnDefinition/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Video}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
+                            <ComboBox Grid.Column="1"
+                                              x:Name="cv" IsEnabled="{Binding Enable.FormatVideo}"
+                                              Template="{StaticResource ComboBoxTemplateForVideo}"
+                                              SelectedValue="{Binding selectedVideo}"
+                                              ItemsSource="{Binding FormatsVideo}">
+                                <ComboBox.ItemContainerStyle>
+                                    <Style TargetType="ComboBoxItem">
+                                        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                    </Style>
+                                </ComboBox.ItemContainerStyle>
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid>
+                                            <Grid.Resources>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Margin" Value="2,0"/>
+                                                    <Setter Property="HorizontalAlignment" Value="Center"/>
+                                                </Style>
+                                            </Grid.Resources>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition SharedSizeGroup="S0" />
+                                                <ColumnDefinition SharedSizeGroup="S1" />
+                                                <ColumnDefinition SharedSizeGroup="S2" />
+                                                <ColumnDefinition SharedSizeGroup="S3" />
+                                                <ColumnDefinition SharedSizeGroup="S4" />
+                                                <ColumnDefinition SharedSizeGroup="S5" />
+                                                <ColumnDefinition SharedSizeGroup="S6" />
+                                            </Grid.ColumnDefinitions>
+                                            <controls:Icons Size="14">
+                                                <controls:Icons.Style>
+                                                    <Style TargetType="controls:Icons">
+                                                        <Setter Property="Kind" Value="None"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding type}" Value="package">
+                                                                <Setter Property="Kind" Value="LinkVariant"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </controls:Icons.Style>
+                                            </controls:Icons>
+                                            <TextBlock FontSize="10" Grid.Column="1" HorizontalAlignment="Left" Text="{Binding resolution}"/>
+                                            <TextBlock FontSize="10" Grid.Column="2" HorizontalAlignment="Center" Text="{Binding dynamic_range}"/>
+                                            <TextBlock FontSize="10" Grid.Column="3" HorizontalAlignment="Center" Text="{Binding fps}"/>
+                                            <TextBlock FontSize="10" Grid.Column="4" Text="{Binding video_ext}"/>
+                                            <TextBlock FontSize="10" Grid.Column="5" Text="{Binding vcodec}"/>
+                                            <TextBlock FontSize="10" Grid.Column="6" HorizontalAlignment="Right" controls:Filesize.Bytes="{Binding filesize}"/>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                                <d:ComboBoxItem IsSelected="True">1920×1080 vp9 30fps 76.58MB</d:ComboBoxItem>
+                            </ComboBox>
+                            <ProgressBar Grid.Column="1" Value="{Binding VideoPersent}" Margin="1,3" IsHitTestVisible="False"
+                                                 BorderThickness="0" Background="Transparent" Foreground="#3000ff00">
+                                <ProgressBar.Style>
+                                    <Style TargetType="ProgressBar">
+                                        <Setter Property="Visibility" Value="Hidden"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsDownload}" Value="True">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </ProgressBar.Style>
+                            </ProgressBar>
+                            <Button Grid.Column="2" Margin="2,2,0,2" Padding="3,0"
+                                    IsEnabled="{Binding Enable.SaveVideo}" Click="Button_SaveVideo" Cursor="Hand">
+                                <controls:Icons Size="14" Kind="Download"/>
+                            </Button>
+                        </Grid>
+                        <!-- Audio -->
+                        <Grid Grid.Row="3">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
+                                <ColumnDefinition/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Audio}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
+                            <ComboBox x:Name="ca" Grid.Column="1"
+                                              Template="{StaticResource ComboBoxTemplateForAudio}"
+                                              SelectedValue="{Binding selectedAudio}" IsEnabled="{Binding Enable.FormatAudio}"
+                                              ItemsSource="{Binding FormatsAudio}">
+                                <ComboBox.ItemContainerStyle>
+                                    <Style TargetType="ComboBoxItem">
+                                        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                        <Setter Property="IsEnabled" Value="True"/>
+                                        <Style.Triggers>
+                                            <MultiDataTrigger>
+                                                <MultiDataTrigger.Conditions>
+                                                    <Condition Binding="{Binding DataContext.selectedVideo.type ,RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ComboBox}}" Value="video"/>
+                                                    <Condition Binding="{Binding type}" Value="package"/>
+                                                </MultiDataTrigger.Conditions>
+                                                <Setter Property="IsEnabled" Value="False"/>
+                                            </MultiDataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </ComboBox.ItemContainerStyle>
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid>
+                                            <Grid.Resources>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Margin" Value="2,0"/>
+                                                    <Setter Property="HorizontalAlignment" Value="Center"/>
+                                                </Style>
+                                            </Grid.Resources>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition SharedSizeGroup="S0" />
+                                                <ColumnDefinition SharedSizeGroup="S1" />
+                                                <ColumnDefinition SharedSizeGroup="S2" />
+                                                <ColumnDefinition SharedSizeGroup="S3" />
+                                                <ColumnDefinition SharedSizeGroup="S4" />
+                                                <ColumnDefinition SharedSizeGroup="S5" />
+                                                <ColumnDefinition SharedSizeGroup="S6" />
+                                            </Grid.ColumnDefinitions>
+                                            <controls:Icons Size="14">
+                                                <controls:Icons.Style>
+                                                    <Style TargetType="controls:Icons">
+                                                        <Setter Property="Kind" Value="None"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding type}" Value="package">
+                                                                <Setter Property="Kind" Value="LinkVariant"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </controls:Icons.Style>
+                                            </controls:Icons>
+                                            <TextBlock FontSize="10" Grid.Column="1" HorizontalAlignment="Left" Text="{Binding asr, StringFormat={}{0}Hz, TargetNullValue=Unknow}"/>
+                                            <TextBlock FontSize="10" Grid.Column="4" Text="{Binding audio_ext}"/>
+                                            <TextBlock FontSize="10" Grid.Column="5" Text="{Binding acodec}"/>
+                                            <TextBlock FontSize="10" Grid.Column="6" HorizontalAlignment="Right" controls:Filesize.Bytes="{Binding filesize}"/>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                                <d:ComboBoxItem IsSelected="True">1920×1080 vp9 30fps 76.58MB</d:ComboBoxItem>
+                            </ComboBox>
+                            <ProgressBar Grid.Column="1" Value="{Binding AudioPersent}" Margin="1,3" IsHitTestVisible="False"
+                                         BorderThickness="0" Background="Transparent" Foreground="#3000ff00">
+                                <ProgressBar.Style>
+                                    <Style TargetType="ProgressBar">
+                                        <Setter Property="Visibility" Value="Hidden"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsDownload}" Value="True">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </ProgressBar.Style>
+                            </ProgressBar>
+                            <Button Grid.Column="2" Margin="2,2,0,2" Padding="3,0"
+                                    IsEnabled="{Binding Enable.SaveAudio}" Click="Button_SaveAudio" Cursor="Hand">
+                                <controls:Icons Size="14" Kind="Download"/>
+                            </Button>
+                        </Grid>
+                        <!-- Subtitle -->
+                        <Grid Grid.Row="4">
+                            <Grid.Style>
+                                <Style TargetType="Grid">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding hasSubtitle}" Value="False">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Grid.Style>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
+                                <ColumnDefinition/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Subtitle}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
+                            <ComboBox x:Name="cs" Grid.Column="1"
+                                      IsEnabled="{Binding Enable.SelectSubtitle}"
+                                      SelectedValue="{Binding selectedSub}"
+                                      DisplayMemberPath="name"
+                                      ItemsSource="{Binding SubtitlesView}"/>
+                            <ProgressBar Grid.Column="1" Value="{Binding SubtitlePersent}" Margin="1,3" IsHitTestVisible="False"
+                                         BorderThickness="0" Background="Transparent" Foreground="#3000ff00">
+                                <ProgressBar.Style>
+                                    <Style TargetType="ProgressBar">
+                                        <Setter Property="Visibility" Value="Hidden"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsDownload}" Value="True">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </ProgressBar.Style>
+                            </ProgressBar>
+                            <Button Grid.Column="2" Margin="2,2,0,2" Padding="3,0"
+                                    IsEnabled="{Binding Enable.SaveSubtitle}" Click="Button_Subtitle" Cursor="Hand">
+                                <controls:Icons Size="14" Kind="Download"/>
+                            </Button>
+                        </Grid>
+                    </Grid>
+                    <!-- Save As -->
+                    <Grid Grid.Row="5" Grid.ColumnSpan="3">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition/>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="Button"/>
+                            </Grid.ColumnDefinitions>
+                            <controls:TextEditor Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.SaveAs}" Text="{Binding TargetDisplay}"
+                                                 IsReadOnly="True" WordWrap="True" Margin="0,2"/>
+                            <Button Grid.Column="1" Margin="2" Cursor="Hand" Click="Button_ExplorerTarget">
+                                <StackPanel Orientation="Horizontal" Margin="4,0">
+                                    <controls:Icons Size="14" Kind="FolderMoveOutline"/>
+                                </StackPanel>
+                            </Button>
+                            <Button Grid.Column="2" IsEnabled="{Binding Enable.Browser}"
+                                    Margin="4,2,2,2" Click="Button_Browser" Cursor="Hand">
+                                <TextBlock Margin="2,0,0,0" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Browse}"/>
+                            </Button>
+                        </Grid>
+                        <Button Grid.Column="1" Margin="2" Cursor="Hand" IsEnabled="{Binding CanCancel}" Click="Button_Cancel">
+                            <Button.Style>
+                                <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsDownload}" Value="False">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                            <StackPanel Orientation="Horizontal" Margin="4,0">
+                                <controls:Icons Size="14" Kind="Download" IsLoading="True"/>
+                                <TextBlock Margin="2,0,0,0" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Cancel}"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Grid.Column="1" IsEnabled="{Binding Enable.Download}" Margin="2" Click="Button_Download" Cursor="Hand">
+                            <Button.Style>
+                                <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsDownload}" Value="True">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                            <StackPanel Orientation="Horizontal" Margin="4,0">
+                                <controls:Icons Size="14" Kind="Download" IsLoading="{Binding IsDownload}"/>
+                                <TextBlock Margin="2,0,0,0" d:Text="Download" Text="{Binding ExecText}"/>
+                            </StackPanel>
                         </Button>
                     </Grid>
-                    <Button Grid.Column="1" Margin="2" Cursor="Hand" IsEnabled="{Binding CanCancel}" Click="Button_Cancel">
-                        <Button.Style>
-                            <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding IsDownload}" Value="False">
-                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Button.Style>
-                        <StackPanel Orientation="Horizontal" Margin="4,0">
-                            <controls:Icons Size="14" Kind="Download" IsLoading="True"/>
-                            <TextBlock Margin="2,0,0,0" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Cancel}"/>
-                        </StackPanel>
-                    </Button>
-                    <Button Grid.Column="1" IsEnabled="{Binding Enable.Download}" Margin="2" Click="Button_Download" Cursor="Hand">
-                        <Button.Style>
-                            <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding IsDownload}" Value="True">
-                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Button.Style>
-                        <StackPanel Orientation="Horizontal" Margin="4,0">
-                            <controls:Icons Size="14" Kind="Download" IsLoading="{Binding IsDownload}"/>
-                            <TextBlock Margin="2,0,0,0" d:Text="Download" Text="{Binding ExecText}"/>
-                        </StackPanel>
-                    </Button>
-
                 </Grid>
-                <!-- -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-            </Grid>
-        </TabItem>
-        <TabItem Header="Proxy"> <!-- TODO: Localize Header -->
-            <Grid Margin="10">
-                <StackPanel>
-                    <TextBlock Text="Proxy Settings" FontWeight="Bold" FontSize="16" Margin="0,0,0,10"/> <!-- TODO: Localize Text -->
-                    <CheckBox x:Name="ProxyEnableCheckBox" Content="Enable Proxy" Margin="0,5"/> <!-- TODO: Localize Content -->
+            </TabItem>
+            <TabItem Header="Proxy"> <!-- TODO: Localize Header -->
+                <Grid Margin="10">
+                    <StackPanel>
+                        <TextBlock Text="Proxy Settings" FontWeight="Bold" FontSize="16" Margin="0,0,0,10"/> <!-- TODO: Localize Text -->
+                        <CheckBox x:Name="ProxyEnableCheckBox" Content="Enable Proxy" Margin="0,5"/> <!-- TODO: Localize Content -->
 
-                    <TextBlock Text="Proxy URL (e.g., http://127.0.0.1 or socks5://127.0.0.1):" Margin="0,5,0,0"/> <!-- TODO: Localize Text -->
-                    <TextBox x:Name="ProxyUrlTextBox" Margin="0,0,0,5"/>
+                        <TextBlock Text="Proxy URL (e.g., http://127.0.0.1 or socks5://127.0.0.1):" Margin="0,5,0,0"/> <!-- TODO: Localize Text -->
+                        <TextBox x:Name="ProxyUrlTextBox" Margin="0,0,0,5"/>
 
-                    <TextBlock Text="Port:" Margin="0,5,0,0"/> <!-- TODO: Localize Text -->
-                    <TextBox x:Name="ProxyPortTextBox" Margin="0,0,0,5"/>
+                        <TextBlock Text="Port:" Margin="0,5,0,0"/> <!-- TODO: Localize Text -->
+                        <TextBox x:Name="ProxyPortTextBox" Margin="0,0,0,5"/>
 
-                    <TextBlock Text="Username (optional):" Margin="0,5,0,0"/> <!-- TODO: Localize Text -->
-                    <TextBox x:Name="ProxyUsernameTextBox" Margin="0,0,0,5"/>
+                        <TextBlock Text="Username (optional):" Margin="0,5,0,0"/> <!-- TODO: Localize Text -->
+                        <TextBox x:Name="ProxyUsernameTextBox" Margin="0,0,0,5"/>
 
-                    <TextBlock Text="Password (optional):" Margin="0,5,0,0"/> <!-- TODO: Localize Text -->
-                    <TextBox x:Name="ProxyPasswordTextBox" Margin="0,0,0,10"/>
+                        <TextBlock Text="Password (optional):" Margin="0,5,0,0"/> <!-- TODO: Localize Text -->
+                        <TextBox x:Name="ProxyPasswordTextBox" Margin="0,0,0,10"/>
 
-                    <Button x:Name="SaveAllSettingsButton" Content="Save All Settings" Click="SaveSettingsButton_Click" HorizontalAlignment="Left" Margin="0,10,0,0"/> <!-- TODO: Localize Content -->
-                </StackPanel>
-            </Grid>
-        </TabItem>
-        <TabItem Header="Download Options"> <!-- TODO: Localize Header -->
-            <Grid Margin="10">
-                <StackPanel>
-                    <TextBlock Text="Video Format Selection" FontWeight="Bold" FontSize="16" Margin="0,0,0,10"/> <!-- TODO: Localize Text -->
-                    <TextBlock Margin="0,5,0,0">
-                        <Run Text="Enter yt-dlp format string (e.g., best, bv*+ba/b, bestvideo[height&lt;=?1080]+bestaudio):"/> <!-- TODO: Localize Text -->
-                        <LineBreak/>
-                        <Run Text="See yt-dlp documentation for format selection options."/> <!-- TODO: Localize Text -->
-                    </TextBlock>
-                    <TextBox x:Name="VideoFormatTextBox" Margin="0,5,0,10" ToolTipService.ToolTip="Enter desired yt-dlp format string."/> <!-- TODO: Localize ToolTip -->
+                        <Button x:Name="SaveAllSettingsButton" Content="Save All Settings" Click="SaveSettingsButton_Click" HorizontalAlignment="Left" Margin="0,10,0,0"/> <!-- TODO: Localize Content -->
+                    </StackPanel>
+                </Grid>
+            </TabItem>
+            <TabItem Header="Download Options"> <!-- TODO: Localize Header -->
+                <Grid Margin="10">
+                    <StackPanel>
+                        <TextBlock Text="Video Format Selection" FontWeight="Bold" FontSize="16" Margin="0,0,0,10"/> <!-- TODO: Localize Text -->
+                        <TextBlock Margin="0,5,0,0">
+                            <Run Text="Enter yt-dlp format string (e.g., best, bv*+ba/b, bestvideo[height&lt;=?1080]+bestaudio):"/> <!-- TODO: Localize Text -->
+                            <LineBreak/>
+                            <Run Text="See yt-dlp documentation for format selection options."/> <!-- TODO: Localize Text -->
+                        </TextBlock>
+                        <TextBox x:Name="VideoFormatTextBox" Margin="0,5,0,10" ToolTipService.ToolTip="Enter desired yt-dlp format string."/> <!-- TODO: Localize ToolTip -->
 
-                    <Separator Margin="0,10"/>
-                    <TextBlock Text="Audio Options" FontWeight="Bold" FontSize="16" Margin="0,10,0,10"/> <!-- TODO: Localize Text -->
+                        <Separator Margin="0,10"/>
+                        <TextBlock Text="Audio Options" FontWeight="Bold" FontSize="16" Margin="0,10,0,10"/> <!-- TODO: Localize Text -->
 
-                    <CheckBox x:Name="AudioOnlyCheckBox" Content="Download audio only" Margin="0,5,0,5"/> <!-- TODO: Localize Content -->
+                        <CheckBox x:Name="AudioOnlyCheckBox" Content="Download audio only" Margin="0,5,0,5"/> <!-- TODO: Localize Content -->
 
-                    <TextBlock Text="Preferred audio format (if downloading audio only):" Margin="0,5,0,0"/> <!-- TODO: Localize Text -->
-                    <ComboBox x:Name="AudioFormatComboBox" Margin="0,5,0,10">
-                        <ComboBoxItem Content="mp3"/>
-                        <ComboBoxItem Content="m4a"/>
-                        <ComboBoxItem Content="opus"/>
-                        <ComboBoxItem Content="aac"/>
-                        <ComboBoxItem Content="flac"/>
-                        <ComboBoxItem Content="vorbis"/>
-                        <ComboBoxItem Content="wav"/>
-                    </ComboBox>
+                        <TextBlock Text="Preferred audio format (if downloading audio only):" Margin="0,5,0,0"/> <!-- TODO: Localize Text -->
+                        <ComboBox x:Name="AudioFormatComboBox" Margin="0,5,0,10">
+                            <ComboBoxItem Content="mp3"/>
+                            <ComboBoxItem Content="m4a"/>
+                            <ComboBoxItem Content="opus"/>
+                            <ComboBoxItem Content="aac"/>
+                            <ComboBoxItem Content="flac"/>
+                            <ComboBoxItem Content="vorbis"/>
+                            <ComboBoxItem Content="wav"/>
+                        </ComboBox>
 
-                    <TextBlock Text="Default Download Folder:" Margin="0,10,0,0"/> <!-- TODO: Localize Text -->
-                    <TextBox x:Name="DownloadPathTextBox" Margin="0,5,0,10" ToolTipService.ToolTip="Folder where downloads will be saved."/> <!-- TODO: Localize ToolTip -->
-                </StackPanel>
-            </Grid>
-        </TabItem>
-        <TabItem Header="{Binding Source={x:Static app:App.Lang}, Path=Main.Advance}">
-            <Grid VerticalAlignment="Top" Margin="4">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="6"/>
-                    <ColumnDefinition/>
-                </Grid.ColumnDefinitions>
-                <!-- Configuration-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="0" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Configuration}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                <ComboBox Grid.Row="0" Grid.Column="2" HorizontalAlignment="Left"
-                              SelectedValue="{Binding selectedConfig}"
-                              DisplayMemberPath="name"
-                              ItemsSource="{Binding ConfigsView}"/>
-                <!--Proxy-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="1" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Proxy}" Margin="0,2" VerticalAlignment="Top" HorizontalAlignment="Right"/>
-                <Grid Grid.Row="1" Grid.Column="2" VerticalAlignment="Top">
+                        <TextBlock Text="Default Download Folder:" Margin="0,10,0,0"/> <!-- TODO: Localize Text -->
+                        <TextBox x:Name="DownloadPathTextBox" Margin="0,5,0,10" ToolTipService.ToolTip="Folder where downloads will be saved."/> <!-- TODO: Localize ToolTip -->
+                    </StackPanel>
+                </Grid>
+            </TabItem>
+            <TabItem Header="{Binding Source={x:Static app:App.Lang}, Path=Main.Advance}">
+                <Grid VerticalAlignment="Top" Margin="4">
                     <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="6"/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
+                    <!-- Configuration -->
+                    <TextBlock Grid.Row="0" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Configuration}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <ComboBox Grid.Row="0" Grid.Column="2" HorizontalAlignment="Left"
+                                  SelectedValue="{Binding selectedConfig}"
+                                  DisplayMemberPath="name"
+                                  ItemsSource="{Binding ConfigsView}"/>
+                    <!--Proxy (now in its own tab) -->
+                    <!--UseCookie -->
+                    <TextBlock Grid.Row="2" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Cookie}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <StackPanel Grid.Row="2" Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Top" Margin="0,2">
+                        <ComboBox SelectedValue="{Binding UseCookie}" SelectedValuePath="Tag" IsEnabled="{Binding Enable.UseCookie}">
+                            <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.CookieWhenNeeded}" Tag="{x:Static m:UseCookie.WhenNeeded}"/>
+                            <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.CookieNever}" Tag="{x:Static m:UseCookie.Never}"/>
+                            <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.CookieAlways}" Tag="{x:Static m:UseCookie.Always}"/>
+                            <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.CookieAsk}" Tag="{x:Static m:UseCookie.Ask}"/>
+                        </ComboBox>
+                        <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.CookieUse}" Margin="4,0" VerticalAlignment="Center"/>
+                        <ComboBox SelectedValue="{Binding CookieType}" SelectedValuePath="Tag" IsEnabled="{Binding Enable.CookieType}">
+                            <ComboBoxItem Content="Chrome" Tag="{x:Static m:CookieType.Chrome}"/>
+                            <ComboBoxItem Content="Edge" Tag="{x:Static m:CookieType.Edge}"/>
+                            <ComboBoxItem Content="Firefox" Tag="{x:Static m:CookieType.Firefox}"/>
+                            <ComboBoxItem Content="Opera" Tag="{x:Static m:CookieType.Opera}"/>
+                            <ComboBoxItem Content="Vivaldi" Tag="{x:Static m:CookieType.Vivaldi}"/>
+                            <Separator/>
+                            <ComboBoxItem Content="Chromium" Tag="{x:Static m:CookieType.Chromium}"/>
+                            <ComboBoxItem Content="Chrome Beta" Tag="{x:Static m:CookieType.Chrome_Beta}"/>
+                        </ComboBox>
+                    </StackPanel>
+                    <!--UseAria2 -->
+                    <TextBlock Grid.Row="3" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Aria2}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <CheckBox Grid.Row="3" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.Aria2Enabled}" IsEnabled="{Binding Enable.UseAria2}" IsChecked="{Binding UseAria2}" Margin="0,2"/>
+                    <!--Embeds -->
+                    <TextBlock Grid.Row="4" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Embeds}" VerticalAlignment="Top" Margin="0,3" HorizontalAlignment="Right"/>
+                    <Grid Grid.Row="4" Grid.Column="2">
+                        <Grid.RowDefinitions>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                        </Grid.RowDefinitions>
+                        <CheckBox Grid.Row="0" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedsThumbnail}" IsChecked="{Binding EmbedThumbnail}"/>
+                        <CheckBox Grid.Row="1" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedsChapters}" IsChecked="{Binding EmbedChapters}"/>
+                        <CheckBox Grid.Row="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedsSubtitles}" IsChecked="{Binding EmbedSubtitles}"/>
+                    </Grid>
+                    <!--TimeRange -->
+                    <StackPanel Grid.Row="5" VerticalAlignment="Center" HorizontalAlignment="Right">
+                        <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRange}" HorizontalAlignment="Right"/>
+                        <TextBlock FontSize="10" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRangeHits}" Foreground="Gray" HorizontalAlignment="Right"/>
+                    </StackPanel>
+                    <controls:TextEditor Grid.Row="5" Grid.Column="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRangeHelper}" Text="{Binding TimeRange}"
+                                             Margin="0,2" EnableHyperlinks="False"/>
+                    <!--LimitRate -->
+                    <TextBlock Grid.Row="6" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.LimitRate}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <controls:TextEditor Grid.Row="6" Grid.Column="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.LimitRateHelper}" Text="{Binding LimitRate}"
+                                             Margin="0,2" EnableHyperlinks="False"/>
+                    <!--Modified -->
+                    <TextBlock Grid.Row="7" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Modified}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <ComboBox Grid.Row="7" Grid.Column="2" SelectedValue="{Binding ModifiedType}" SelectedValuePath="Tag" IsEnabled="{Binding Enable.UseCookie}" HorizontalAlignment="Left">
+                        <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ModifiedModified}" Tag="{x:Static m:ModifiedType.Modified}"/>
+                        <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ModifiedCreated}" Tag="{x:Static m:ModifiedType.Created}"/>
+                        <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ModifiedUpload}" Tag="{x:Static m:ModifiedType.Upload}"/>
+                    </ComboBox>
+                </Grid>
+            </TabItem>
+            <TabItem Header="Queue"> <!-- TODO: Localize Header -->
+                <Grid>
+                    <DataGrid x:Name="DownloadQueueDataGrid"
+                              ItemsSource="{Binding DownloadQueue}"
+                              AutoGenerateColumns="False"
+                              CanUserAddRows="False"
+                              IsReadOnly="True"
+                              SelectionMode="Single">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="File Name" Binding="{Binding FileName}" Width="*"/> <!-- TODO: Localize Header -->
+                            <DataGridTextColumn Header="URL" Binding="{Binding Url}" Width="2*"/> <!-- TODO: Localize Header -->
+                            <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="100"/> <!-- TODO: Localize Header -->
+                            <DataGridTemplateColumn Header="Progress" Width="120"> <!-- TODO: Localize Header -->
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <ProgressBar Value="{Binding Progress}" Maximum="100" Height="18"/>
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                            <DataGridTextColumn Header="Output Path" Binding="{Binding OutputPath}" Width="2*"/> <!-- TODO: Localize Header -->
+                            <DataGridTextColumn Header="Error" Binding="{Binding ErrorMessage}" Width="*" Visibility="{Binding ErrorMessage, Converter={StaticResource NullOrEmptyToVisibilityConverter}}"/> <!-- TODO: Localize Header -->
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </Grid>
+            </TabItem>
+            <TabItem Header="{Binding Source={x:Static app:App.Lang}, Path=Main.Options}">
+                <Grid Margin="4" VerticalAlignment="Top">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="6"/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <!-- 0 -->
                         <RowDefinition/>
+                        <!-- 1 -->
+                        <RowDefinition/>
+                        <!-- 2 -->
+                        <RowDefinition/>
+                        <!-- 3 -->
+                        <RowDefinition/>
+                        <!-- 4 -->
+                        <RowDefinition/>
+                        <!-- 5 -->
+                        <RowDefinition/>
+                        <!-- 6 -->
                         <RowDefinition/>
                     </Grid.RowDefinitions>
-                    <CheckBox Grid.Row="0" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ProxyEnabled}" IsChecked="{Binding ProxyEnabled}"/>
-                    <controls:TextEditor Grid.Row="1" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.ProxyHelper}" Text="{Binding ProxyUrl}" 
-                                         Margin="0,2" EnableHyperlinks="False"/>
+                    <!--Notifications -->
+                    <TextBlock Grid.Row="0" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Notifications}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                    <CheckBox Grid.Row="0" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.NotificationsEnabled}" IsEnabled="{Binding Enable.UseNotifications}" IsChecked="{Binding UseNotifications}"/>
+                    <!--Notifications Sound -->
+                    <TextBlock Grid.Row="1" Margin="0,5,0,5" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.NotificationsSound}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <Grid Grid.Row="1" Grid.Column="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <controls:TextEditor IsReadOnly="True" Margin="0" Text="{Binding PathNotify}" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.SoundDefault}" Multiline="False" VerticalAlignment="Center"/>
+                        <Button Grid.Column="1" Focusable="False" Margin="2,0,0,0" Padding="0" Click="Button_PlayNotify">
+                            <controls:Icons Kind="Play" />
+                        </Button>
+                        <ToggleButton Grid.Column="2" Focusable="False" Margin="2,0,0,0" Checked="ToggleButton_Checked_Sound">
+                            <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                                <controls:Icons Size="14" Kind="FolderSettings"/>
+                                <controls:Icons Kind="MenuDown" Size="16"/>
+                            </StackPanel>
+                        </ToggleButton>
+                    </Grid>
+                    <!--Always on Top -->
+                    <TextBlock Grid.Row="2" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.AlwaysOnTop}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                    <CheckBox Grid.Row="2" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.AlwaysOnTopEnabled}" IsChecked="{Binding AlwaysOnTop}"/>
+                    <!--Potistion & Size -->
+                    <TextBlock Grid.Row="3" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.RememberWindowState}" Margin="0,2" HorizontalAlignment="Right" VerticalAlignment="Top"/>
+                    <StackPanel Grid.Row="3" Grid.Column="2">
+                        <CheckBox Content="{Binding Source={x:Static app:App.Lang}, Path=Main.RememberWindowPosition}" IsChecked="{Binding RememberWindowStatePosition}"/>
+                        <CheckBox Content="{Binding Source={x:Static app:App.Lang}, Path=Main.RememberWindowSize}" IsChecked="{Binding RememberWindowStateSize}"/>
+                    </StackPanel>
+                    <!--Scale -->
+                    <TextBlock Grid.Row="4" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Scale}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                    <Grid Grid.Row="4" Grid.Column="2" >
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBox MinWidth="36" Padding="2" Margin="0,2,2,0" VerticalAlignment="Center">
+                            <i:Interaction.Behaviors>
+                                <b:TextBoxNumber MinValue="80" MaxValue="200" Number="{Binding Scale}" Changed="TextBoxNumber_Changed"/>
+                            </i:Interaction.Behaviors>
+                        </TextBox>
+                        <TextBlock Grid.Column="1" Text="%" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+                    </Grid>
+                    <!--Automatically download -->
+                    <TextBlock Grid.Row="5" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.AutoDownload}" Margin="0,5,0,5" HorizontalAlignment="Right"/>
+                    <CheckBox Grid.Row="5" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.AutoDownloadAnalysed}" IsChecked="{Binding AutoDownloadAnalysed}"/>
+                    <!--Temporary folder -->
+                    <TextBlock Grid.Row="6" Margin="0,5,0,5" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.TemporaryFolder}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <Grid Grid.Row="6" Grid.Column="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <controls:TextEditor IsReadOnly="True" Text="{Binding PathTEMP}" Margin="0" Multiline="False" VerticalAlignment="Center"/>
+                        <ToggleButton Grid.Column="1" Focusable="False" Margin="2,0,0,0" Checked="ToggleButton_Checked">
+                            <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                                <controls:Icons Size="14" Kind="FolderSettings"/>
+                                <controls:Icons Kind="MenuDown" Size="16"/>
+                            </StackPanel>
+                        </ToggleButton>
+                    </Grid>
                 </Grid>
-                <!--UseCookie-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="2" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Cookie}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                <StackPanel Grid.Row="2" Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Top" Margin="0,2">
-                    <ComboBox SelectedValue="{Binding UseCookie}" SelectedValuePath="Tag" IsEnabled="{Binding Enable.UseCookie}">
-                        <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.CookieWhenNeeded}" Tag="{x:Static m:UseCookie.WhenNeeded}"/>
-                        <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.CookieNever}" Tag="{x:Static m:UseCookie.Never}"/>
-                        <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.CookieAlways}" Tag="{x:Static m:UseCookie.Always}"/>
-                        <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.CookieAsk}" Tag="{x:Static m:UseCookie.Ask}"/>
-                    </ComboBox>
-                    <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.CookieUse}" Margin="4,0" VerticalAlignment="Center"/>
-                    <ComboBox SelectedValue="{Binding CookieType}" SelectedValuePath="Tag" IsEnabled="{Binding Enable.CookieType}">
-                        <ComboBoxItem Content="Chrome" Tag="{x:Static m:CookieType.Chrome}"/>
-                        <ComboBoxItem Content="Edge" Tag="{x:Static m:CookieType.Edge}"/>
-                        <ComboBoxItem Content="Firefox" Tag="{x:Static m:CookieType.Firefox}"/>
-                        <ComboBoxItem Content="Opera" Tag="{x:Static m:CookieType.Opera}"/>
-                        <ComboBoxItem Content="Vivaldi" Tag="{x:Static m:CookieType.Vivaldi}"/>
-                        <Separator/>
-                        <ComboBoxItem Content="Chromium" Tag="{x:Static m:CookieType.Chromium}"/>
-                        <ComboBoxItem Content="Chrome Beta" Tag="{x:Static m:CookieType.Chrome_Beta}"/>
-                    </ComboBox>
-                </StackPanel>
-                <!--UseAria2-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="3" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Aria2}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                <CheckBox Grid.Row="3" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.Aria2Enabled}" IsEnabled="{Binding Enable.UseAria2}" IsChecked="{Binding UseAria2}" Margin="0,2"/>
-                <!--Embeds-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="4" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Embeds}" VerticalAlignment="Top" Margin="0,3" HorizontalAlignment="Right"/>
-                <Grid Grid.Row="4" Grid.Column="2">
-                    <Grid.RowDefinitions>
-                        <RowDefinition/>
-                        <RowDefinition/>
-                        <RowDefinition/>
-                    </Grid.RowDefinitions>
-                    <CheckBox Grid.Row="0" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedsThumbnail}" IsChecked="{Binding EmbedThumbnail}"/>
-                    <CheckBox Grid.Row="1" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedsChapters}" IsChecked="{Binding EmbedChapters}"/>
-                    <CheckBox Grid.Row="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedsSubtitles}" IsChecked="{Binding EmbedSubtitles}"/>
-                </Grid>
-                <!--EmbedSubs-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <!--
-                    <TextBlock Grid.Row="4" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedSubs}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                    <CheckBox Grid.Row="4" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedSubsEnabled}" Margin="0,2" IsChecked="{Binding EmbedSub}"/>
-                    -->
-                <!--TimeRange-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <StackPanel Grid.Row="5" VerticalAlignment="Center" HorizontalAlignment="Right">
-                    <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRange}" HorizontalAlignment="Right"/>
-                    <TextBlock FontSize="10" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRangeHits}" Foreground="Gray" HorizontalAlignment="Right"/>
-                </StackPanel>
-                <controls:TextEditor Grid.Row="5" Grid.Column="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRangeHelper}" Text="{Binding TimeRange}" 
-                                         Margin="0,2" EnableHyperlinks="False"/>
-                <!--LimitRate-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="6" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.LimitRate}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                <controls:TextEditor Grid.Row="6" Grid.Column="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.LimitRateHelper}" Text="{Binding LimitRate}" 
-                                         Margin="0,2" EnableHyperlinks="False"/>
-                <!--Modified-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="7" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Modified}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                <ComboBox Grid.Row="7" Grid.Column="2" SelectedValue="{Binding ModifiedType}" SelectedValuePath="Tag" IsEnabled="{Binding Enable.UseCookie}" HorizontalAlignment="Left">
-                    <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ModifiedModified}" Tag="{x:Static m:ModifiedType.Modified}"/>
-                    <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ModifiedCreated}" Tag="{x:Static m:ModifiedType.Created}"/>
-                    <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ModifiedUpload}" Tag="{x:Static m:ModifiedType.Upload}"/>
-                </ComboBox>
-            </Grid>
-        </TabItem>
-        <TabItem Header="Queue"> <!-- TODO: Localize Header -->
-            <Grid>
-                <DataGrid x:Name="DownloadQueueDataGrid"
-                          ItemsSource="{Binding DownloadQueue}"
-                          AutoGenerateColumns="False"
-                          CanUserAddRows="False"
-                          IsReadOnly="True"
-                          SelectionMode="Single">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="File Name" Binding="{Binding FileName}" Width="*"/> <!-- TODO: Localize Header -->
-                        <DataGridTextColumn Header="URL" Binding="{Binding Url}" Width="2*"/> <!-- TODO: Localize Header -->
-                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="100"/> <!-- TODO: Localize Header -->
-                        <DataGridTemplateColumn Header="Progress" Width="120"> <!-- TODO: Localize Header -->
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate>
-                                    <ProgressBar Value="{Binding Progress}" Maximum="100" Height="18"/>
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
-                        <DataGridTextColumn Header="Output Path" Binding="{Binding OutputPath}" Width="2*"/> <!-- TODO: Localize Header -->
-                        <DataGridTextColumn Header="Error" Binding="{Binding ErrorMessage}" Width="*" Visibility="{Binding ErrorMessage, Converter={StaticResource NullOrEmptyToVisibilityConverter}}"/> <!-- TODO: Localize Header -->
-                    </DataGrid.Columns>
-                </DataGrid>
-            </Grid>
-        </TabItem>
-        <TabItem Header="{Binding Source={x:Static app:App.Lang}, Path=Main.Options}">
-            <Grid Margin="4" VerticalAlignment="Top">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="6"/>
-                    <ColumnDefinition/>
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <!-- 0 -->
-                    <RowDefinition/>
-                    <!-- 1 -->
-                    <RowDefinition/>
-                    <!-- 2 -->
-                    <RowDefinition/>
-                    <!-- 3 -->
-                    <RowDefinition/>
-                    <!-- 4 -->
-                    <RowDefinition/>
-                    <!-- 5 -->
-                    <RowDefinition/>
-                    <!-- 6 -->
-                    <RowDefinition/>
-                </Grid.RowDefinitions>
-                <!--Notifications-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="0" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Notifications}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-                <CheckBox Grid.Row="0" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.NotificationsEnabled}" IsEnabled="{Binding Enable.UseNotifications}" IsChecked="{Binding UseNotifications}"/>
-                <!--Notifications Sound-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="1" Margin="0,5,0,5" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.NotificationsSound}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                <Grid Grid.Row="1" Grid.Column="2">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <controls:TextEditor IsReadOnly="True" Margin="0" Text="{Binding PathNotify}" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.SoundDefault}" Multiline="False" VerticalAlignment="Center"/>
-                    <Button Grid.Column="1" Focusable="False" Margin="2,0,0,0" Padding="0" Click="Button_PlayNotify">
-                        <controls:Icons Kind="Play" />
-                    </Button>
-                    <ToggleButton Grid.Column="2" Focusable="False" Margin="2,0,0,0" Checked="ToggleButton_Checked_Sound">
-                        <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
-                            <controls:Icons Size="14" Kind="FolderSettings"/>
-                            <controls:Icons Kind="MenuDown" Size="16"/>
-                        </StackPanel>
-                    </ToggleButton>
-                </Grid>
-                <!--Always on Top-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="2" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.AlwaysOnTop}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-                <CheckBox Grid.Row="2" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.AlwaysOnTopEnabled}" IsChecked="{Binding AlwaysOnTop}"/>
-                <!--Potistion & Size-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="3" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.RememberWindowState}" Margin="0,2" HorizontalAlignment="Right" VerticalAlignment="Top"/>
-                <StackPanel Grid.Row="3" Grid.Column="2">
-                    <CheckBox Content="{Binding Source={x:Static app:App.Lang}, Path=Main.RememberWindowPosition}" IsChecked="{Binding RememberWindowStatePosition}"/>
-                    <CheckBox Content="{Binding Source={x:Static app:App.Lang}, Path=Main.RememberWindowSize}" IsChecked="{Binding RememberWindowStateSize}"/>
-                </StackPanel>
-                <!--Scale-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="4" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Scale}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-                <Grid Grid.Row="4" Grid.Column="2" >
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBox MinWidth="36" Padding="2" Margin="0,2,2,0" VerticalAlignment="Center">
-                        <i:Interaction.Behaviors>
-                            <b:TextBoxNumber MinValue="80" MaxValue="200" Number="{Binding Scale}" Changed="TextBoxNumber_Changed"/>
-                        </i:Interaction.Behaviors>
-                    </TextBox>
-                    <TextBlock Grid.Column="1" Text="%" HorizontalAlignment="Left" VerticalAlignment="Center"/>
-                </Grid>
-                <!--Automatically download-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="5" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.AutoDownload}" Margin="0,5,0,5" HorizontalAlignment="Right"/>
-                <CheckBox Grid.Row="5" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.AutoDownloadAnalysed}" IsChecked="{Binding AutoDownloadAnalysed}"/>
-                <!--Temporary folder-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="6" Margin="0,5,0,5" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.TemporaryFolder}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                <Grid Grid.Row="6" Grid.Column="2">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <controls:TextEditor IsReadOnly="True" Text="{Binding PathTEMP}" Margin="0" Multiline="False" VerticalAlignment="Center"/>
-                    <ToggleButton Grid.Column="1" Focusable="False" Margin="2,0,0,0" Checked="ToggleButton_Checked">
-                        <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
-                            <controls:Icons Size="14" Kind="FolderSettings"/>
-                            <controls:Icons Kind="MenuDown" Size="16"/>
-                        </StackPanel>
-                    </ToggleButton>
-                </Grid>
-            </Grid>
-        </TabItem>
-    </TabControl>
+            </TabItem>
+        </TabControl>
+    </Grid>
 </Window>


### PR DESCRIPTION
I've replaced the entire content of yt-dlp-gui/Views/Main.xaml with the complete XAML you provided.

This version places the MonitorIconStyle in Grid.Resources and applies it to the controls:Icons element within the ToggleButton. This change is intended by you to resolve the persistent MC3088 XAML parsing error.