### PR TITLE
I temporarily renamed the `App` partial class in `App.Path.cs`.

### DIFF
--- a/yt-dlp-gui/App/App.Path.cs
+++ b/yt-dlp-gui/App/App.Path.cs
@@ -5,7 +5,7 @@ using System.Windows;
 
 namespace yt_dlp_gui {
     using IoPath = System.IO.Path;
-    public partial class App : System.Windows.Application { // Explicitly qualified Application
+    public partial class App_PathPart : System.Windows.Application { // Temporarily renamed
         public static string AppExe;
         public static string AppPath;
         public static string AppName;


### PR DESCRIPTION
I renamed the partial class in `yt-dlp-gui/App/App.Path.cs` from `App` to `App_PathPart`.

This is a diagnostic step to help me determine the source of the persistent CS0101 error (duplicate definition of `App`).

If the original CS0101 error for `App` disappears, it suggests the conflict was between `App.xaml.cs` and `App.Path.cs`. If it persists, the conflict likely involves auto-generated code from `App.xaml`.

New compilation errors due to members now being in `App_PathPart` are expected and part of this diagnostic process.