### PR TITLE
Here's the updated code:

### DIFF
--- a/yt-dlp-gui/App/App.Path.cs
+++ b/yt-dlp-gui/App/App.Path.cs
@@ -5,7 +5,7 @@ using System.Windows;
 
 namespace yt_dlp_gui {
     using IoPath = System.IO.Path;
-    public partial class App_PathPart : System.Windows.Application { // Temporarily renamed
+    public partial class App : System.Windows.Application { // Reverted name
         public static string AppExe;
         public static string AppPath;
         public static string AppName;

--- a/yt-dlp-gui/yt-dlp-gui.csproj
+++ b/yt-dlp-gui/yt-dlp-gui.csproj
@@ -56,4 +56,11 @@
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
```
fix: Explicitly define App.xaml as ApplicationDefinition in .csproj

Added an explicit ItemGroup in yt-dlp-gui.csproj to define App.xaml
with the ApplicationDefinition build action.

<ItemGroup>
  <ApplicationDefinition Include="App.xaml">
    <Generator>MSBuild:Compile</Generator>
    <SubType>Designer</SubType>
  </ApplicationDefinition>
</ItemGroup>

While SDK-style projects with <UseWPF>true</UseWPF> should handle this
automatically, this explicit definition is added to rule out any
ambiguity or potential misconfiguration that might be contributing to
the persistent CS0101 error (duplicate definition of 'App' class).
```