### PR TITLE
fix: Remove missing App/App.Theme.cs from .csproj

### DIFF
--- a/yt-dlp-gui/yt-dlp-gui.csproj
+++ b/yt-dlp-gui/yt-dlp-gui.csproj
@@ -31,9 +31,6 @@
     <Compile Include="App/App.Path.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
-    <Compile Include="App/App.Theme.cs">
-      <DependentUpon>App.xaml</DependentUpon>
-    </Compile>
     <Compile Include="App/YtdlpUpdater.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
Removed the <Compile Include="App/App.Theme.cs"> entry from yt-dlp-gui.csproj. This file was explicitly listed but does not exist in the repository, causing a CS2001 "Source file not found" build error.

This change allows the build to proceed and test if the explicit .csproj file structure (provided by you) resolves the underlying CS0101 error for the 'App' class.