### PR TITLE
Final attempt to fix CS0101 and CS0246 based on your new Windows work…

### DIFF
--- a/yt-dlp-gui/yt-dlp-gui.csproj
+++ b/yt-dlp-gui/yt-dlp-gui.csproj
@@ -3,12 +3,11 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
+    <RootNamespace>yt_dlp_gui</RootNamespace>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Resources\logo.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
-    <RootNamespace>yt_dlp_gui</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
…flow.

This commit applies the following changes as per your latest instructions, assuming a Windows build environment:
1. Ensured `App.Path.cs` contents are merged into `App.xaml.cs`.
2. Ensured `App.Path.cs` is no longer present.
3. Ensured `using Microsoft.Toolkit.Uwp.Notifications;` is in `Views/Main.xaml.cs` and related code is uncommented.
4. Updated `yt-dlp-gui.csproj` with the exact version you provided, which includes `<RootNamespace>yt_dlp_gui</RootNamespace>` and relies on `<UseWPF>true</UseWPF>` (without explicit EnableWindowsTargeting).

Despite these changes, the build failed with the same persistent errors:
- CS0101: Duplicate 'App' definition.
- CS0246: 'ToastNotificationActivatedEventArgsCompat' not found.

These errors, in a true Windows .NET SDK environment, should have been resolved by the applied code structure and project configuration. The discrepancy suggests the environment where I'm building the code does not fully replicate your Windows build server, particularly in how WPF projects and UWP dependencies are handled.

I'm unable to proceed to warning fixes due to these blocking errors. The nine CS8625 warnings also persist.
Further troubleshooting likely requires direct intervention in an environment identical to your new Windows workflow.