### PR TITLE
Fix CS0101: Resolve App class redefinition error

### DIFF
--- a/yt-dlp-gui/App.xaml
+++ b/yt-dlp-gui/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="yt_dlp_gui.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="Views/Main.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/yt-dlp-gui/yt-dlp-gui.csproj
+++ b/yt-dlp-gui/yt-dlp-gui.csproj
@@ -37,6 +37,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ApplicationDefinition Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
     <Compile Update="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
This commit addresses a persistent CS0101 error ("The namespace 'yt_dlp_gui' already contains a definition for 'App'") by restructuring the WPF application startup files.

Changes include:
1. I added a standard `App.xaml` file to `yt-dlp-gui/`. This file was potentially missing or misconfigured, which is a common cause of this error.
2. I updated `yt-dlp-gui/yt-dlp-gui.csproj` to explicitly include `App.xaml` as an `<ApplicationDefinition>` and ensure `App.xaml.cs` correctly depends on it. This clarifies the build process for the `App` class.
3. I restored the original logic within `yt-dlp-gui/App.xaml.cs`. After making the structural changes to `App.xaml` and the `.csproj` file, the original, more complex `App.xaml.cs` (which includes theme and path management) should no longer conflict with an auto-generated `App` class.

Note: The project is a WPF application. The build was attempted in a Linux-based environment where WPF-specific build targets are unavailable, resulting in an MSB4019 error. Therefore, these changes need to be tested and verified in a Windows development environment capable of building WPF applications.