### PR TITLE
Fix MC1003: Prevent duplicate ApplicationDefinition items

### DIFF
--- a/yt-dlp-gui/yt-dlp-gui.csproj
+++ b/yt-dlp-gui/yt-dlp-gui.csproj
@@ -8,6 +8,7 @@
     <ApplicationIcon>Resources\logo.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <EnableDefaultApplicationDefinitionItems>false</EnableDefaultApplicationDefinitionItems>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This commit resolves the MC1003 error ("Project file cannot specify more than one ApplicationDefinition element") by ensuring only one ApplicationDefinition is processed by the build system.

The fix involves adding `<EnableDefaultApplicationDefinitionItems>false</EnableDefaultApplicationDefinitionItems>` to the main PropertyGroup in `yt-dlp-gui.csproj`. This prevents the .NET SDK from implicitly including `App.xaml` as an ApplicationDefinition by convention, which was conflicting with the existing explicit `<ApplicationDefinition Include="App.xaml">` entry.

This ensures that only the explicitly defined ApplicationDefinition for App.xaml is used, resolving the build error.