### PR TITLE
Fix MC1003: Rely on SDK default for ApplicationDefinition

### DIFF
--- a/yt-dlp-gui/yt-dlp-gui.csproj
+++ b/yt-dlp-gui/yt-dlp-gui.csproj
@@ -8,7 +8,6 @@
     <ApplicationIcon>Resources\logo.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <EnableDefaultApplicationDefinitionItems>false</EnableDefaultApplicationDefinitionItems>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,10 +37,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ApplicationDefinition Include="App.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </ApplicationDefinition>
     <Compile Update="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
This commit attempts to resolve the persistent MC1003 error ("Project file cannot specify more than one ApplicationDefinition element") by modifying `yt-dlp-gui.csproj` to fully rely on the .NET SDK's default behavior for discovering and processing `App.xaml`.

Changes include:
1. Removed the explicit `<ApplicationDefinition Include="App.xaml">` item.
2. Removed the `<EnableDefaultApplicationDefinitionItems>false</EnableDefaultApplicationDefinitionItems>` property from the main PropertyGroup.

By removing these explicit configurations, the SDK should now use its convention-based mechanism to identify `App.xaml` as the application's entry point. The `DependentUpon` metadata for `App.xaml.cs` has been verified to ensure the code-behind is still correctly associated with `App.xaml`.

This approach is taken after previous attempts to explicitly manage ApplicationDefinition and disable SDK defaults did not resolve the error.