### PR TITLE
Refactor: Create minimal App.xaml and App.xaml.cs for build verification

### DIFF
--- a/yt-dlp-gui/App.xaml
+++ b/yt-dlp-gui/App.xaml
@@ -3,5 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="Views/Main.xaml">
     <Application.Resources>
+        <!-- Keep this empty or minimal for now -->
     </Application.Resources>
 </Application>

--- a/yt-dlp-gui/App.xaml.cs
+++ b/yt-dlp-gui/App.xaml.cs
@@ -1,71 +1,14 @@
-// App.xaml.cs - FINAL MERGED VERSION
-using System;
-using System.IO;
 using System.Windows;
-using System.Windows.Threading;
-using yt_dlp_gui.Models;
-using yt_dlp_gui.Wrappers;
 
 namespace yt_dlp_gui
 {
     public partial class App : Application
     {
-        public static Config AppConfig { get; set; } = new();
-        public static Lang AppLang { get; set; } = new();
-        public static ytDlp ytDlp { get; set; } = new();
-
         protected override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
-            CheckAppData();
-            AppConfig = Config.Load();
-            DispatcherUnhandledException += App_DispatcherUnhandledException;
-            TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
-            System.AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
-            InitTheme();
-        }
-
-        private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e) {
-            var exception = e.ExceptionObject as Exception;
-            MessageBox.Show(exception?.Message, "Error:CurrentDomain");
-        }
-        private void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e) {
-            var exception = e.Exception as Exception;
-            MessageBox.Show(exception?.Message, "Error:TaskScheduler");
-        }
-        private void App_DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e) {
-            var exception = e.Exception as Exception;
-            MessageBox.Show(exception?.Message, "Error:Dispatcher");
-        }
-
-        // Merged from App.Path.cs
-        public static string AppData = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "yt-dlp-gui");
-        public static string PathConfig = Path.Combine(AppData, "config.json");
-        public static string PathLangs = Path.Combine(AppData, "langs");
-        public static string PathNotify = Path.Combine(AppData, "notify.wav");
-        public static string PathDlp = Path.Combine(AppData, "yt-dlp.exe");
-        public static string PathAria2c = Path.Combine(AppData, "aria2c.exe");
-        public static string PathFFmpeg = Path.Combine(AppData, "ffmpeg.exe");
-        public static string PathFFprobe = Path.Combine(AppData, "ffprobe.exe");
-        public static string PathTEMP = Path.Combine(Path.GetTempPath(), "yt-dlp-gui");
-
-        public static void CheckAppData() {
-            if (!Directory.Exists(AppData)) Directory.CreateDirectory(AppData);
-            if (!Directory.Exists(PathLangs)) Directory.CreateDirectory(PathLangs);
-            if (!Directory.Exists(PathTEMP)) Directory.CreateDirectory(PathTEMP);
-        }
-
-        // Merged from App.Theme.cs
-        public ResourceDictionary ThemeDictionary => Resources.MergedDictionaries[0];
-        public void InitTheme() {
-            ThemeDictionary.MergedDictionaries.Clear();
-            ThemeDictionary.MergedDictionaries.Add(new ResourceDictionary() { Source = new Uri("Resources/Styles/Style.xaml", UriKind.Relative) });
-            ThemeDictionary.MergedDictionaries.Add(new ResourceDictionary() { Source = new Uri($"Resources/Languages/{AppConfig.Lang}.xaml", UriKind.Relative) });
-            ChangeTheme(AppConfig.Theme);
-        }
-        public void ChangeTheme(Theme theme) {
-            AppConfig.Theme = theme;
-            ThemeDictionary.MergedDictionaries[0] = new ResourceDictionary() { Source = new Uri($"Resources/Styles/{theme}.xaml", UriKind.Relative) };
+            // Further initialization will be added here in Phase 2,
+            // calling out to helper classes, once this minimal version builds successfully.
         }
     }
 }


### PR DESCRIPTION
This commit implements Phase 1 of a larger refactoring plan aimed at resolving persistent CS0101 errors (duplicate App definition).

Changes include:
1.  `yt-dlp-gui/App.xaml` has been reduced to a minimal structure, primarily defining the Application class and StartupUri.
2.  `yt-dlp-gui/App.xaml.cs` has been reduced to an absolute minimum, containing only the partial class definition and a basic OnStartup method.
3.  `yt-dlp-gui/yt-dlp-gui.csproj` has been cleaned to rely on .NET SDK default behaviors for handling `App.xaml` (as ApplicationDefinition) and `App.xaml.cs` (as Compile, with correct `DependentUpon` metadata). Explicit ApplicationDefinition items and related SDK flags have been removed.

This minimal configuration is intended to provide a stable baseline and confirm that the CS0101 error is resolved before reintroducing more complex application logic in a refactored way.

The next step is for you to trigger a build in your Windows environment (via GitHub Actions) to verify these changes.