### PR TITLE
Here's a breakdown of the changes I've made to help diagnose the CS01…

### DIFF
--- a/yt-dlp-gui/MyApplication.xaml
+++ b/yt-dlp-gui/MyApplication.xaml
@@ -1,4 +1,4 @@
-<Application x:Class="yt_dlp_gui.App"
+<Application x:Class="yt_dlp_gui.MyApplication"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="Views/Main.xaml">

--- a/yt-dlp-gui/MyApplication.xaml.cs
+++ b/yt-dlp-gui/MyApplication.xaml.cs
@@ -2,7 +2,7 @@ using System.Windows;
 
 namespace yt_dlp_gui
 {
-    public partial class App : Application
+    public partial class MyApplication : Application // Changed class name here
     {
         protected override void OnStartup(StartupEventArgs e)
         {

--- a/yt-dlp-gui/yt-dlp-gui.csproj
+++ b/yt-dlp-gui/yt-dlp-gui.csproj
@@ -12,15 +12,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ApplicationDefinition Include="App.xaml">
+    <ApplicationDefinition Include="MyApplication.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="App.xaml.cs">
-      <DependentUpon>App.xaml</DependentUpon>
+    <Compile Include="MyApplication.xaml.cs">
+      <DependentUpon>MyApplication.xaml</DependentUpon>
     </Compile>
     <Compile Include="AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
…01 error (duplicate definition of the application class):

I've renamed `App.xaml` to `MyApplication.xaml` and `App.xaml.cs` to `MyApplication.xaml.cs`. I also updated the `x:Class` directive in `MyApplication.xaml` to `yt_dlp_gui.MyApplication`, and the class definition in `MyApplication.xaml.cs` to `yt_dlp_gui.MyApplication`. Finally, I updated `yt-dlp-gui.csproj` to reflect these new filenames and the class name for the `ApplicationDefinition` and its dependent `Compile` item.

The project continues to use `<EnableDefaultItems>false</EnableDefaultItems>` with all files explicitly included in the .csproj. The `MyApplication.xaml` and `MyApplication.xaml.cs` files are the minimal versions.

This change aims to determine if the CS0101 error is specific to the name "App" or if it occurs with any class designated as the application entry point under the current build conditions.