### PR TITLE
Fix C# syntax errors in ViewModels and Views

### DIFF
--- a/yt-dlp-gui/Views/Main.xaml.cs
+++ b/yt-dlp-gui/Views/Main.xaml.cs
@@ -377,9 +377,8 @@ Data.TargetPath = "."; // Temporary
         }
         public void InitConfiguration() {
             Data.Configs.Clear();
-            Data.Configs.Add(new Config() { name = "None" /* MyApplication.Lang.Main.ConfigurationNone */ });
-            // var cp = MyApplication.Path(MyApplication.Folders.configs); // Path, Folders are missing
-            var cp = "configs"; // Temporary
+            Data.Configs.Add(new Config() { name = "None" }); // Temporary: Was MyApplication.Lang.Main.ConfigurationNone
+            var cp = "configs"; // Temporary: Was MyApplication.Path(MyApplication.Folders.configs)
             var fs = Directory.Exists(cp)
                 ? Directory.EnumerateFiles(cp).OrderBy(x => x)
                 : Enumerable.Empty<string>();

--- a/yt-dlp-gui/Views/Release.xaml.cs
+++ b/yt-dlp-gui/Views/Release.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Libs;
+using Libs;
 using System;
 using System.ComponentModel;
 using System.Linq;
@@ -22,25 +22,27 @@ namespace yt_dlp_gui.Views {
             if (releaseData.Any()) {
                 Data.Markdown = String.Empty;
                 foreach (var release in releaseData) {
-                    if (true) // Temporary stand-in for version check
+                    if (true) { // Temporary stand-in for version check
                     // if (string.Compare(MyApplication.CurrentVersion, release.tag_name) < 0) { // CurrentVersion is missing
-                        Data.Markdown += $"# {release.tag_name}\n";
-                        Data.Markdown += $"{release.body}\n";
-                        Data.Markdown += $"# Assets\n";
+                        Data.Markdown += $"# {release.tag_name}\n"; // Escaped newline
+                        Data.Markdown += $"{release.body}\n"; // Escaped newline
+                        Data.Markdown += $"# Assets\n"; // Escaped newline
                         foreach (var asset in release.assets) {
-                            Data.Markdown += $"* [{asset.name}]({asset.browser_download_url})\n";
+                            Data.Markdown += $"* [{asset.name}]({asset.browser_download_url})\n"; // Escaped newline
                         }
-                        Data.Markdown += $"---\n";
+                        Data.Markdown += $"---\n"; // Escaped newline
                     }
                 }
                 if (string.IsNullOrEmpty(Data.Markdown)) {
-                    Data.Markdown = $"# {"No New Updates Available"}"; // MyApplication.Lang.Releases.NoUpdated
+                    // Data.Markdown = $"# {MyApplication.Lang.Releases.NoUpdated}"; // Lang is missing
+                    Data.Markdown = $"# {"No New Updates Available"}"; // Temporary
                 }
             }
         }
         public class ReleaseData : INotifyPropertyChanged {
             public event PropertyChangedEventHandler? PropertyChanged;
-            public string Markdown { get; set; } = $"# {"Loading..."}"; // MyApplication.Lang.Releases.Loading
+            // public string Markdown { get; set; } = $"# {MyApplication.Lang.Releases.Loading}"; // Lang is missing
+            public string Markdown { get; set; } = $"# {"Loading..."}"; // Temporary
         }
 
         private void Button_Click(object sender, RoutedEventArgs e) {


### PR DESCRIPTION
This commit addresses C# syntax errors (CS1010, CS1012, CS1519) that were occurring in `Views/Main.xaml.cs` and `Views/Release.xaml.cs`.

These errors were likely introduced during previous automated steps that involved commenting out lines and replacing them with temporary hardcoded values. The fixes involve:
- Correcting string literal and comment formatting in `Views/Main.xaml.cs` around lines 307 and 309.
- Rewriting `Views/Release.xaml.cs` with careful attention to string literals (using explicit `\n` for newlines) and comment syntax to ensure correctness.

This aims to resolve the immediate compilation blockers so that further build errors (if any) can be assessed.