### PR TITLE
Fix: Apply ultra-simple syntax to Main.xaml.cs lines 307 & 309

### DIFF
--- a/yt-dlp-gui/Views/Main.xaml.cs
+++ b/yt-dlp-gui/Views/Main.xaml.cs
@@ -377,8 +377,8 @@ Data.TargetPath = "."; // Temporary
         }
         public void InitConfiguration() {
             Data.Configs.Clear();
-            Data.Configs.Add(new Config() { name = "None" }); // Temporary: Was MyApplication.Lang.Main.ConfigurationNone
-            var cp = "configs"; // Temporary: Was MyApplication.Path(MyApplication.Folders.configs)
+            Data.Configs.Add(new Config() { name = "None" });
+            var cp = "configs";
             var fs = Directory.Exists(cp)
                 ? Directory.EnumerateFiles(cp).OrderBy(x => x)
                 : Enumerable.Empty<string>();


### PR DESCRIPTION
This commit applies highly specific and simplified C# statements to lines around 307 and 309 in `yt-dlp-gui/Views/Main.xaml.cs`. These lines were persistently causing CS1010 (Newline in constant) and CS1012 (Too many characters in character literal) errors.

The problematic lines, which involved temporary hardcoding and comments during previous refactoring steps, have been replaced with their simplest possible valid forms:
- `Data.Configs.Add(new Config() { name = "None" });`
- `var cp = "configs";`

This is a focused attempt to eliminate any lingering syntax issues on these lines.