### PR TITLE
I've configured the `.csproj` file to enable access to Windows Runtim…

### DIFF
--- a/yt-dlp-gui/yt-dlp-gui.csproj
+++ b/yt-dlp-gui/yt-dlp-gui.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <RootNamespace>yt_dlp_gui</RootNamespace>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Resources\logo.ico</ApplicationIcon>


### PR DESCRIPTION
…e (WinRT) APIs.

Specifically, I modified `yt-dlp-gui.csproj` to resolve issues with using `Windows.UI.Notifications`.

Here's what I changed:
- I updated the `<TargetFramework>` from `net6.0-windows` to `net6.0-windows10.0.19041.0`. This targets a specific Windows SDK version necessary for WinRT API availability.
- I added `<EnableWindowsTargeting>true</EnableWindowsTargeting>` to the main `<PropertyGroup>`. This property is required by the .NET SDK to build projects targeting specific Windows versions on non-Windows build systems or when certain Windows SDK features are used.

These changes should address the CS0246 error ("The type or namespace name 'Windows' could not be found") that you were seeing after introducing `Windows.UI.Notifications.ToastNotification`. They should also resolve the subsequent NETSDK1100 build configuration error.