### PR TITLE
Fix: Correct YamlDotNet API usage and re-verify other errors

### DIFF
--- a/yt-dlp-gui/Libs/Yaml.cs
+++ b/yt-dlp-gui/Libs/Yaml.cs
@@ -42,7 +42,7 @@ namespace Libs.Yaml {
         }
         public static string Serialize(object obj) {
             var s = new SerializerBuilder()
-                .WithDefaultValuesHandling(DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitEmptyCollections)
+                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults)
                 .Build();
             return s.Serialize(obj);
         }
@@ -56,7 +56,7 @@ namespace Libs.Yaml {
                 using (var yaml = new StreamWriter(info.FullName, false, Encoding.UTF8)) {
                     var s = new SerializerBuilder()
                     //.WithTypeInspector(inner => new SortedTypeInspector(inner))
-                    .WithDefaultValuesHandling(DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitEmptyCollections)
+                    .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults)
                     .Build();
                     s.Serialize(yaml, graph);
                 }


### PR DESCRIPTION
- I've corrected the YamlDotNet API call in `Libs/Yaml.cs`:
  - I changed `WithDefaultValuesHandling` to `ConfigureDefaultValuesHandling`.
  - I used `DefaultValuesHandling.OmitDefaults` for serializing objects, aligning with YamlDotNet v11.0.0+ API for omitting default values. This addresses the CS1061 error.

- I re-verified `Models/DownloadItem.cs`:
  - The `DownloadStatus` enum appears correct and includes all necessary members (`Queued`, `Downloading`, `Completed`, `Failed`) as per the current file content. Persistent CS0117 errors in CI might indicate a file versioning issue in the build environment.

- I re-investigated `Views/Main.xaml.cs` for CS1593 (delegate arguments):
  - The call to `DLP.Exec` and the provided lambda for the `stdall` callback appear to match the `DLP.Exec` method signature in `Wrappers/DLP.cs` (expecting `Action<DownloadItem?, string>`). The explicit naming of arguments from a previous step is maintained. Persistent CS1593 errors in CI are puzzling and may also point to environment-specific file version discrepancies.

This commit aims to resolve the YamlDotNet-related build error. Other errors persist in CI logs but their causes are not evident from the codebase state visible during this session.