### PR TITLE
Fix: Ensure two-argument lambdas for all dlp.Exec callbacks

### DIFF
--- a/yt-dlp-gui/Views/Main.xaml.cs
+++ b/yt-dlp-gui/Views/Main.xaml.cs
@@ -460,10 +460,12 @@ namespace yt_dlp_gui.Views {
             }
             if (Data.UseOutput) dlp.Output("%(title)s.%(ext)s");
             ClearStatus();
-            dlp.Exec(null, std => {
-                Data.Video = JsonConvert.DeserializeObject<Video>(std, new JsonSerializerSettings() {
-                    NullValueHandling = NullValueHandling.Ignore
-                });
+            dlp.Exec(
+                itemToUpdate: null,
+                stdall: (item, std) => {
+                    Data.Video = JsonConvert.DeserializeObject<Video>(std, new JsonSerializerSettings() {
+                        NullValueHandling = NullValueHandling.Ignore
+                    });
                 Data.Chapters.Clear();
                 if (Data.Video != null && Data.Video.chapters != null && Data.Video.chapters.Any()) { // Added null check for Data.Video
                     Data.Chapters.Add(new Chapters() { title = "All Chapters" /* MyApplication.Lang.Main.ChaptersAll */, type = ChaptersType.None });


### PR DESCRIPTION
Corrects the lambda signature for a `dlp.Exec` call within the `GetInfo` method in `yt-dlp-gui/Views/Main.xaml.cs`. The callback for `stdall` was previously using a single parameter, which is incompatible with the `Action<DownloadItem?, string>` delegate type expected by `DLP.Exec`. It has been changed to use `(item, std) => { ... }`.

Other calls to `dlp.Exec` in the same file were reviewed and confirmed to already use the correct two-argument lambda signatures for their callbacks.

This change directly addresses the CS1593 error ("Delegate 'Action<DownloadItem?, string>' does not take 1 arguments") by ensuring the provided lambdas match the expected delegate signatures.