### PR TITLE
Fix: Resolve XAML MC3050 'Cannot find the type App' errors

### DIFF
--- a/yt-dlp-gui/MyApplication.xaml.cs
+++ b/yt-dlp-gui/MyApplication.xaml.cs
@@ -1,9 +1,12 @@
 using System.Windows;
+using yt_dlp_gui.Models;
 
 namespace yt_dlp_gui
 {
     public partial class MyApplication : Application // Changed class name here
     {
+        public static Lang AppLang { get; } = new Lang();
+
         protected override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);

--- a/yt-dlp-gui/Themes/CustomUI.xaml
+++ b/yt-dlp-gui/Themes/CustomUI.xaml
@@ -90,11 +90,11 @@
                                     <ColumnDefinition Width="Auto" SharedSizeGroup="C4"/>
                                     <ColumnDefinition Width="Auto" SharedSizeGroup="C5"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Column="1" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.VideoRes}"/>
-                                <TextBlock Grid.Column="2" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.VideoFPS}"/>
-                                <TextBlock Grid.Column="3" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.VideoExt}"/>
-                                <TextBlock Grid.Column="4" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.VideoCodec}"/>
-                                <TextBlock Grid.Column="5" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.VideoSize}"/>
+                                <TextBlock Grid.Column="1" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.VideoRes}"/>
+                                <TextBlock Grid.Column="2" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.VideoFPS}"/>
+                                <TextBlock Grid.Column="3" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.VideoExt}"/>
+                                <TextBlock Grid.Column="4" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.VideoCodec}"/>
+                                <TextBlock Grid.Column="5" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.VideoSize}"/>
                             </Grid>
                             <Separator Grid.Row="1" Height="2"/>
                             <ScrollViewer Grid.Row="2" x:Name="DropDownScrollViewer">
@@ -184,12 +184,12 @@
                                     <ColumnDefinition Width="Auto" SharedSizeGroup="S5"/>
                                     <ColumnDefinition Width="Auto" SharedSizeGroup="S6"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Column="1" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.VideoRes}"/>
-                                <TextBlock Grid.Column="2" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.VideoDynamicRange}"/>
-                                <TextBlock Grid.Column="3" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.VideoFPS}"/>
-                                <TextBlock Grid.Column="4" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.VideoExt}"/>
-                                <TextBlock Grid.Column="5" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.VideoCodec}"/>
-                                <TextBlock Grid.Column="6" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.VideoSize}"/>
+                                <TextBlock Grid.Column="1" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.VideoRes}"/>
+                                <TextBlock Grid.Column="2" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.VideoDynamicRange}"/>
+                                <TextBlock Grid.Column="3" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.VideoFPS}"/>
+                                <TextBlock Grid.Column="4" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.VideoExt}"/>
+                                <TextBlock Grid.Column="5" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.VideoCodec}"/>
+                                <TextBlock Grid.Column="6" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.VideoSize}"/>
                             </Grid>
                             <Separator Grid.Row="1" Height="2"/>
                             <ScrollViewer Grid.Row="2" x:Name="DropDownScrollViewer">
@@ -278,10 +278,10 @@
                                     <ColumnDefinition Width="Auto" SharedSizeGroup="S5"/>
                                     <ColumnDefinition Width="Auto" SharedSizeGroup="S6"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Column="1" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.AudioSampleRate}"/>
-                                <TextBlock Grid.Column="4" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.AudioExt}"/>
-                                <TextBlock Grid.Column="5" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.AudioCodec}"/>
-                                <TextBlock Grid.Column="6" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.AudioSize}"/>
+                                <TextBlock Grid.Column="1" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.AudioSampleRate}"/>
+                                <TextBlock Grid.Column="4" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.AudioExt}"/>
+                                <TextBlock Grid.Column="5" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.AudioCodec}"/>
+                                <TextBlock Grid.Column="6" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.AudioSize}"/>
                             </Grid>
                             <Separator Grid.Row="1" Height="2"/>
                             <ScrollViewer Grid.Row="2" x:Name="DropDownScrollViewer">

--- a/yt-dlp-gui/Views/About.xaml
+++ b/yt-dlp-gui/Views/About.xaml
@@ -9,7 +9,7 @@
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
         SizeToContent="Height"
-        Title="{Binding Source={x:Static app:App.Lang}, Path=About.About}" Width="420">
+         Title="{Binding Source={x:Static app:MyApplication.AppLang}, Path=About.About}" Width="420">
     <Window.Resources>
         <ControlTemplate TargetType="ContentControl" x:Key="WindowLogo">
             <Controls:Icons Kind="Information" Size="16"/>

--- a/yt-dlp-gui/Views/Main.xaml
+++ b/yt-dlp-gui/Views/Main.xaml
@@ -11,7 +11,7 @@
         xmlns:b="clr-namespace:yt_dlp_gui.Controls.Behaviors"
         xmlns:converters="clr-namespace:yt_dlp_gui.Converters"
         mc:Ignorable="d" Style="{DynamicResource WindowStyle}"
-        Title="{Binding Source={x:Static app:App.Lang}, Path=AppName}" Width="600" Height="380"
+        Title="{Binding Source={x:Static app:MyApplication.AppLang}, Path=AppName}" Width="600" Height="380"
         Background="{StaticResource BackgroundColour}"
         Closed="Window_Closed"
         Icon="pack://application:,,,/Resources/logo.ico">
@@ -54,7 +54,7 @@
                             <MenuItem.Icon>
                                 <controls:Icons Kind="MenuDown" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                             </MenuItem.Icon>
-                            <MenuItem Header="{Binding Source={x:Static app:App.Lang}, Path=Main.About}" Click="MenuItem_About_Click">
+                            <MenuItem Header="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.About}" Click="MenuItem_About_Click">
                                 <MenuItem.Icon>
                                     <controls:Icons Size="14" Kind="Information"/>
                                 </MenuItem.Icon>
@@ -70,7 +70,7 @@
     </Window.Resources>
     <Grid x:Name="MainGrid"> <!-- Added x:Name for scale transform -->
         <TabControl TabStripPlacement="Top" Margin="6,4">
-            <TabItem Header="{Binding Source={x:Static app:App.Lang}, Path=Main.Main}">
+            <TabItem Header="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Main}">
                 <Grid Margin="4" Grid.IsSharedSizeScope="True">
                     <Grid.Resources>
                         <Style TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
@@ -114,7 +114,7 @@
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="Auto" SharedSizeGroup="Button"/>
                         </Grid.ColumnDefinitions>
-                        <controls:TextEditor Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.Url}" Margin="0,2" IsEnabled="{Binding Enable.Url}"
+                        <controls:TextEditor Helper="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Url}" Margin="0,2" IsEnabled="{Binding Enable.Url}"
                                      WordWrap="True"
                                      Text="{Binding Url}" Syntax="url" EnableHyperlinks="False">
                             <controls:TextEditor.ContextMenu>
@@ -148,7 +148,7 @@
                         <Button Grid.Column="2" IsEnabled="{Binding Enable.Analyze}" Margin="2" Click="Button_Analyze">
                             <StackPanel Orientation="Horizontal" Margin="4,0">
                                 <controls:Icons Size="14" Kind="Magnify" IsLoading="{Binding IsAnalyze}"/>
-                                <TextBlock Margin="2,0,0,0" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Analyze}"/>
+                                <TextBlock Margin="2,0,0,0" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Analyze}"/>
                             </StackPanel>
                         </Button>
                     </Grid>
@@ -167,7 +167,7 @@
                                     <controls:ActualSize ActualWidth="{Binding ImageWidth}"/>
                                 </i:Interaction.Behaviors>
                                 <Grid>
-                                    <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Thumbnail}" Foreground="Gray" IsHitTestVisible="False" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Thumbnail}" Foreground="Gray" IsHitTestVisible="False" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                     <Image VerticalAlignment="Center" Stretch="UniformToFill"
                                            Source="{Binding Thumbnail, TargetNullValue={x:Null}}">
                                         <Image.CacheMode>
@@ -191,7 +191,7 @@
                                             </Style>
                                         </TextBlock.Style>
                                     </TextBlock>
-                                    <TextBlock HorizontalAlignment="Right" VerticalAlignment="Bottom" Padding="4,0" Background="Red" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Live}">
+                                    <TextBlock HorizontalAlignment="Right" VerticalAlignment="Bottom" Padding="4,0" Background="Red" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Live}">
                                         <TextBlock.Style>
                                             <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
                                                 <Style.Triggers>
@@ -213,7 +213,7 @@
                                     </ContextMenu>
                                 </Border.ContextMenu>
                             </Border>
-                            <CheckBox Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.DownloadThumb}" VerticalAlignment="Center"
+                            <CheckBox Grid.Column="2" Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.DownloadThumb}" VerticalAlignment="Center"
                               IsEnabled="{Binding Enable.SaveThumbnail}"
                               Margin="2,0" IsChecked="{Binding SaveThumbnail}"
                               HorizontalAlignment="Left"/>
@@ -240,7 +240,7 @@
                         </ItemsControl>
                     </Grid>
                     <!-- Title -->
-                    <controls:TextEditor Grid.Row="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.Title}" Text="{Binding Video.title}"
+                    <controls:TextEditor Grid.Row="2" Helper="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Title}" Text="{Binding Video.title}"
                                  Margin="0,2" IsReadOnly="True" WordWrap="True"
                                  EnableHyperlinks="False">
                         <controls:TextEditor.ContextMenu>
@@ -254,7 +254,7 @@
                         </controls:TextEditor.ContextMenu>
                     </controls:TextEditor>
                     <!-- Desc -->
-                    <controls:TextEditor Grid.Row="3" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.Title}"
+                    <controls:TextEditor Grid.Row="3" Helper="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Title}"
                                  Margin="0,2" Syntax="desc"
                                  Multiline="True" EnableHyperlinks="True" IsReadOnly="True"
                                  Text="{Binding Video.description}">
@@ -293,7 +293,7 @@
                                 <ColumnDefinition/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Chapters}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
+                            <TextBlock Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Chapters}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
                             <ComboBox x:Name="cc" Grid.Column="1"
                                       IsEnabled="{Binding Enable.SelectChapters}"
                                       HorizontalContentAlignment="Stretch"
@@ -344,7 +344,7 @@
                                 <ColumnDefinition/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Video}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
+                            <TextBlock Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Video}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
                             <ComboBox Grid.Column="1"
                                               x:Name="cv" IsEnabled="{Binding Enable.FormatVideo}"
                                               Template="{StaticResource ComboBoxTemplateForVideo}"
@@ -421,7 +421,7 @@
                                 <ColumnDefinition/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Audio}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
+                            <TextBlock Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Audio}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
                             <ComboBox x:Name="ca" Grid.Column="1"
                                               Template="{StaticResource ComboBoxTemplateForAudio}"
                                               SelectedValue="{Binding selectedAudio}" IsEnabled="{Binding Enable.FormatAudio}"
@@ -514,7 +514,7 @@
                                 <ColumnDefinition/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Subtitle}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
+                            <TextBlock Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Subtitle}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,4,0"/>
                             <ComboBox x:Name="cs" Grid.Column="1"
                                       IsEnabled="{Binding Enable.SelectSubtitle}"
                                       SelectedValue="{Binding selectedSub}"
@@ -551,7 +551,7 @@
                                 <ColumnDefinition Width="Auto"/>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="Button"/>
                             </Grid.ColumnDefinitions>
-                            <controls:TextEditor Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.SaveAs}" Text="{Binding TargetDisplay}"
+                            <controls:TextEditor Helper="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.SaveAs}" Text="{Binding TargetDisplay}"
                                                  IsReadOnly="True" WordWrap="True" Margin="0,2"/>
                             <Button Grid.Column="1" Margin="2" Cursor="Hand" Click="Button_ExplorerTarget">
                                 <StackPanel Orientation="Horizontal" Margin="4,0">
@@ -560,7 +560,7 @@
                             </Button>
                             <Button Grid.Column="2" IsEnabled="{Binding Enable.Browser}"
                                     Margin="4,2,2,2" Click="Button_Browser" Cursor="Hand">
-                                <TextBlock Margin="2,0,0,0" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Browse}"/>
+                                <TextBlock Margin="2,0,0,0" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Browse}"/>
                             </Button>
                         </Grid>
                         <Button Grid.Column="1" Margin="2" Cursor="Hand" IsEnabled="{Binding CanCancel}" Click="Button_Cancel">
@@ -575,7 +575,7 @@
                             </Button.Style>
                             <StackPanel Orientation="Horizontal" Margin="4,0">
                                 <controls:Icons Size="14" Kind="Download" IsLoading="True"/>
-                                <TextBlock Margin="2,0,0,0" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Cancel}"/>
+                                <TextBlock Margin="2,0,0,0" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Cancel}"/>
                             </StackPanel>
                         </Button>
                         <Button Grid.Column="1" IsEnabled="{Binding Enable.Download}" Margin="2" Click="Button_Download" Cursor="Hand">
@@ -650,7 +650,7 @@
                     </StackPanel>
                 </Grid>
             </TabItem>
-            <TabItem Header="{Binding Source={x:Static app:App.Lang}, Path=Main.Advance}">
+            <TabItem Header="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Advance}">
                 <Grid VerticalAlignment="Top" Margin="4">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -668,22 +668,22 @@
                         <ColumnDefinition/>
                     </Grid.ColumnDefinitions>
                     <!-- Configuration -->
-                    <TextBlock Grid.Row="0" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Configuration}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <TextBlock Grid.Row="0" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Configuration}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                     <ComboBox Grid.Row="0" Grid.Column="2" HorizontalAlignment="Left"
                                   SelectedValue="{Binding selectedConfig}"
                                   DisplayMemberPath="name"
                                   ItemsSource="{Binding ConfigsView}"/>
                     <!--Proxy (now in its own tab) -->
                     <!--UseCookie -->
-                    <TextBlock Grid.Row="2" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Cookie}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <TextBlock Grid.Row="2" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Cookie}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                     <StackPanel Grid.Row="2" Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Top" Margin="0,2">
                         <ComboBox SelectedValue="{Binding UseCookie}" SelectedValuePath="Tag" IsEnabled="{Binding Enable.UseCookie}">
-                            <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.CookieWhenNeeded}" Tag="{x:Static m:UseCookie.WhenNeeded}"/>
-                            <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.CookieNever}" Tag="{x:Static m:UseCookie.Never}"/>
-                            <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.CookieAlways}" Tag="{x:Static m:UseCookie.Always}"/>
-                            <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.CookieAsk}" Tag="{x:Static m:UseCookie.Ask}"/>
+                            <ComboBoxItem Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.CookieWhenNeeded}" Tag="{x:Static m:UseCookie.WhenNeeded}"/>
+                            <ComboBoxItem Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.CookieNever}" Tag="{x:Static m:UseCookie.Never}"/>
+                            <ComboBoxItem Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.CookieAlways}" Tag="{x:Static m:UseCookie.Always}"/>
+                            <ComboBoxItem Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.CookieAsk}" Tag="{x:Static m:UseCookie.Ask}"/>
                         </ComboBox>
-                        <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.CookieUse}" Margin="4,0" VerticalAlignment="Center"/>
+                        <TextBlock Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.CookieUse}" Margin="4,0" VerticalAlignment="Center"/>
                         <ComboBox SelectedValue="{Binding CookieType}" SelectedValuePath="Tag" IsEnabled="{Binding Enable.CookieType}">
                             <ComboBoxItem Content="Chrome" Tag="{x:Static m:CookieType.Chrome}"/>
                             <ComboBoxItem Content="Edge" Tag="{x:Static m:CookieType.Edge}"/>
@@ -696,37 +696,37 @@
                         </ComboBox>
                     </StackPanel>
                     <!--UseAria2 -->
-                    <TextBlock Grid.Row="3" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Aria2}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                    <CheckBox Grid.Row="3" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.Aria2Enabled}" IsEnabled="{Binding Enable.UseAria2}" IsChecked="{Binding UseAria2}" Margin="0,2"/>
+                    <TextBlock Grid.Row="3" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Aria2}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <CheckBox Grid.Row="3" Grid.Column="2" Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Aria2Enabled}" IsEnabled="{Binding Enable.UseAria2}" IsChecked="{Binding UseAria2}" Margin="0,2"/>
                     <!--Embeds -->
-                    <TextBlock Grid.Row="4" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Embeds}" VerticalAlignment="Top" Margin="0,3" HorizontalAlignment="Right"/>
+                    <TextBlock Grid.Row="4" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Embeds}" VerticalAlignment="Top" Margin="0,3" HorizontalAlignment="Right"/>
                     <Grid Grid.Row="4" Grid.Column="2">
                         <Grid.RowDefinitions>
                             <RowDefinition/>
                             <RowDefinition/>
                             <RowDefinition/>
                         </Grid.RowDefinitions>
-                        <CheckBox Grid.Row="0" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedsThumbnail}" IsChecked="{Binding EmbedThumbnail}"/>
-                        <CheckBox Grid.Row="1" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedsChapters}" IsChecked="{Binding EmbedChapters}"/>
-                        <CheckBox Grid.Row="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedsSubtitles}" IsChecked="{Binding EmbedSubtitles}"/>
+                        <CheckBox Grid.Row="0" Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.EmbedsThumbnail}" IsChecked="{Binding EmbedThumbnail}"/>
+                        <CheckBox Grid.Row="1" Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.EmbedsChapters}" IsChecked="{Binding EmbedChapters}"/>
+                        <CheckBox Grid.Row="2" Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.EmbedsSubtitles}" IsChecked="{Binding EmbedSubtitles}"/>
                     </Grid>
                     <!--TimeRange -->
                     <StackPanel Grid.Row="5" VerticalAlignment="Center" HorizontalAlignment="Right">
-                        <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRange}" HorizontalAlignment="Right"/>
-                        <TextBlock FontSize="10" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRangeHits}" Foreground="Gray" HorizontalAlignment="Right"/>
+                        <TextBlock Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.TimeRange}" HorizontalAlignment="Right"/>
+                        <TextBlock FontSize="10" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.TimeRangeHits}" Foreground="Gray" HorizontalAlignment="Right"/>
                     </StackPanel>
-                    <controls:TextEditor Grid.Row="5" Grid.Column="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRangeHelper}" Text="{Binding TimeRange}"
+                    <controls:TextEditor Grid.Row="5" Grid.Column="2" Helper="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.TimeRangeHelper}" Text="{Binding TimeRange}"
                                              Margin="0,2" EnableHyperlinks="False"/>
                     <!--LimitRate -->
-                    <TextBlock Grid.Row="6" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.LimitRate}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                    <controls:TextEditor Grid.Row="6" Grid.Column="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.LimitRateHelper}" Text="{Binding LimitRate}"
+                    <TextBlock Grid.Row="6" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.LimitRate}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <controls:TextEditor Grid.Row="6" Grid.Column="2" Helper="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.LimitRateHelper}" Text="{Binding LimitRate}"
                                              Margin="0,2" EnableHyperlinks="False"/>
                     <!--Modified -->
-                    <TextBlock Grid.Row="7" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Modified}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <TextBlock Grid.Row="7" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Modified}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                     <ComboBox Grid.Row="7" Grid.Column="2" SelectedValue="{Binding ModifiedType}" SelectedValuePath="Tag" IsEnabled="{Binding Enable.UseCookie}" HorizontalAlignment="Left">
-                        <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ModifiedModified}" Tag="{x:Static m:ModifiedType.Modified}"/>
-                        <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ModifiedCreated}" Tag="{x:Static m:ModifiedType.Created}"/>
-                        <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ModifiedUpload}" Tag="{x:Static m:ModifiedType.Upload}"/>
+                        <ComboBoxItem Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.ModifiedModified}" Tag="{x:Static m:ModifiedType.Modified}"/>
+                        <ComboBoxItem Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.ModifiedCreated}" Tag="{x:Static m:ModifiedType.Created}"/>
+                        <ComboBoxItem Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.ModifiedUpload}" Tag="{x:Static m:ModifiedType.Upload}"/>
                     </ComboBox>
                 </Grid>
             </TabItem>
@@ -779,17 +779,17 @@
                         <RowDefinition/>
                     </Grid.RowDefinitions>
                     <!--Notifications -->
-                    <TextBlock Grid.Row="0" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Notifications}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-                    <CheckBox Grid.Row="0" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.NotificationsEnabled}" IsEnabled="{Binding Enable.UseNotifications}" IsChecked="{Binding UseNotifications}"/>
+                    <TextBlock Grid.Row="0" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Notifications}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                    <CheckBox Grid.Row="0" Grid.Column="2" Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.NotificationsEnabled}" IsEnabled="{Binding Enable.UseNotifications}" IsChecked="{Binding UseNotifications}"/>
                     <!--Notifications Sound -->
-                    <TextBlock Grid.Row="1" Margin="0,5,0,5" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.NotificationsSound}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <TextBlock Grid.Row="1" Margin="0,5,0,5" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.NotificationsSound}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                     <Grid Grid.Row="1" Grid.Column="2">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition/>
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <controls:TextEditor IsReadOnly="True" Margin="0" Text="{Binding PathNotify}" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.SoundDefault}" Multiline="False" VerticalAlignment="Center"/>
+                        <controls:TextEditor IsReadOnly="True" Margin="0" Text="{Binding PathNotify}" Helper="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.SoundDefault}" Multiline="False" VerticalAlignment="Center"/>
                         <Button Grid.Column="1" Focusable="False" Margin="2,0,0,0" Padding="0" Click="Button_PlayNotify">
                             <controls:Icons Kind="Play" />
                         </Button>
@@ -801,16 +801,16 @@
                         </ToggleButton>
                     </Grid>
                     <!--Always on Top -->
-                    <TextBlock Grid.Row="2" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.AlwaysOnTop}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-                    <CheckBox Grid.Row="2" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.AlwaysOnTopEnabled}" IsChecked="{Binding AlwaysOnTop}"/>
+                    <TextBlock Grid.Row="2" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.AlwaysOnTop}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                    <CheckBox Grid.Row="2" Grid.Column="2" Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.AlwaysOnTopEnabled}" IsChecked="{Binding AlwaysOnTop}"/>
                     <!--Potistion & Size -->
-                    <TextBlock Grid.Row="3" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.RememberWindowState}" Margin="0,2" HorizontalAlignment="Right" VerticalAlignment="Top"/>
+                    <TextBlock Grid.Row="3" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.RememberWindowState}" Margin="0,2" HorizontalAlignment="Right" VerticalAlignment="Top"/>
                     <StackPanel Grid.Row="3" Grid.Column="2">
-                        <CheckBox Content="{Binding Source={x:Static app:App.Lang}, Path=Main.RememberWindowPosition}" IsChecked="{Binding RememberWindowStatePosition}"/>
-                        <CheckBox Content="{Binding Source={x:Static app:App.Lang}, Path=Main.RememberWindowSize}" IsChecked="{Binding RememberWindowStateSize}"/>
+                        <CheckBox Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.RememberWindowPosition}" IsChecked="{Binding RememberWindowStatePosition}"/>
+                        <CheckBox Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.RememberWindowSize}" IsChecked="{Binding RememberWindowStateSize}"/>
                     </StackPanel>
                     <!--Scale -->
-                    <TextBlock Grid.Row="4" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Scale}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                    <TextBlock Grid.Row="4" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.Scale}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
                     <Grid Grid.Row="4" Grid.Column="2" >
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
@@ -824,10 +824,10 @@
                         <TextBlock Grid.Column="1" Text="%" HorizontalAlignment="Left" VerticalAlignment="Center"/>
                     </Grid>
                     <!--Automatically download -->
-                    <TextBlock Grid.Row="5" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.AutoDownload}" Margin="0,5,0,5" HorizontalAlignment="Right"/>
-                    <CheckBox Grid.Row="5" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.AutoDownloadAnalysed}" IsChecked="{Binding AutoDownloadAnalysed}"/>
+                    <TextBlock Grid.Row="5" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.AutoDownload}" Margin="0,5,0,5" HorizontalAlignment="Right"/>
+                    <CheckBox Grid.Row="5" Grid.Column="2" Content="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.AutoDownloadAnalysed}" IsChecked="{Binding AutoDownloadAnalysed}"/>
                     <!--Temporary folder -->
-                    <TextBlock Grid.Row="6" Margin="0,5,0,5" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.TemporaryFolder}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <TextBlock Grid.Row="6" Margin="0,5,0,5" Text="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Main.TemporaryFolder}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                     <Grid Grid.Row="6" Grid.Column="2">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition/>

--- a/yt-dlp-gui/Views/Release.xaml
+++ b/yt-dlp-gui/Views/Release.xaml
@@ -8,7 +8,7 @@
         mc:Ignorable="d"
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
-        Title="{Binding Source={x:Static app:App.Lang}, Path=Releases.Releases}" Height="300" Width="400">
+        Title="{Binding Source={x:Static app:MyApplication.AppLang}, Path=Releases.Releases}" Height="300" Width="400">
     <Window.Style>
         <Style TargetType="Window" BasedOn="{StaticResource DialogStyle}">
             <Setter Property="ResizeMode" Value="CanResizeWithGrip"/>


### PR DESCRIPTION
This commit addresses the MC3050 errors in XAML files by:
1.  Adding a `public static Lang AppLang` property to the `MyApplication` class in `yt-dlp-gui/MyApplication.xaml.cs`. This property provides access to localization strings.
2.  Updating affected XAML files (`Themes/CustomUI.xaml`, `Views/About.xaml`, `Views/Main.xaml`, `Views/Release.xaml`) to use `{x:Static app:MyApplication.AppLang}` for their bindings to localization resources. This replaces the previous incorrect references to `app:App.Lang`.

The `xmlns:app="clr-namespace:yt_dlp_gui"` declarations in XAML were confirmed to be correct. These changes ensure that XAML files correctly locate and bind to the application's static resources.