### PR TITLE
Refine workflow trigger to master branch only

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -2,9 +2,7 @@ name: yt-dlp GUI CI Builder
 
 on:
   push:
-    branches: [ "**" ] # Trigger for all branches
-  pull_request:
-    branches: [ "**" ] # Trigger for all branches
+    branches: [ "master" ]
 
 jobs:
 


### PR DESCRIPTION
This commit updates the GitHub Actions workflow (`.github/workflows/dotnet-desktop.yml`) to trigger builds exclusively on pushes to the `master` branch.

Previously, the workflow was configured to run on pushes to all branches and on all pull requests. This change aligns the CI process with your request to build only upon commits to the `master` branch.