### PR TITLE
Feat: Add option for yt-dlp to handle video/audio muxing directly

### DIFF
--- a/yt-dlp-gui/ViewModels/Main.cs
+++ b/yt-dlp-gui/ViewModels/Main.cs
@@ -230,6 +230,7 @@ namespace yt_dlp_gui.Views {
             public ModifiedType ModifiedType { get; set; } = ModifiedType.Modified;
             public string TimeRange { get; set; } = string.Empty;
             public string LimitRate { get; set; } = string.Empty;
+            public bool LetYtDlpMux { get; set; } = false;
             public Enable Enable { get; set; } = new();
             public bool AutoSaveConfig { get; set; } = false;
             public string Html { get; set; } = string.Empty;
@@ -399,11 +400,12 @@ namespace yt_dlp_gui.Views {
             [Description("Advance")]
             [YamlMember(Order = 1301)] public string ConfigurationFile { get; set; } = string.Empty;
             [YamlMember(Order = 1302)] public bool UseAria2 { get; set; } = false;
-            [YamlMember(Order = 1303)] public bool EmbedThumbnail { get; set; } = false;
-            [YamlMember(Order = 1304)] public bool EmbedChapters { get; set; } = false;
-            [YamlMember(Order = 1305)] public bool EmbedSubtitles { get; set; } = false;
-            [YamlMember(Order = 1306)] public string LimitRate { get; set; } = string.Empty;
-            [YamlMember(Order = 1307)] public ModifiedType ModifiedType { get; set; } = ModifiedType.Modified;
+            [YamlMember(Order = 1303)] public bool LetYtDlpMux { get; set; } = false;
+            [YamlMember(Order = 1304)] public bool EmbedThumbnail { get; set; } = false;
+            [YamlMember(Order = 1305)] public bool EmbedChapters { get; set; } = false;
+            [YamlMember(Order = 1306)] public bool EmbedSubtitles { get; set; } = false;
+            [YamlMember(Order = 1307)] public string LimitRate { get; set; } = string.Empty;
+            [YamlMember(Order = 1308)] public ModifiedType ModifiedType { get; set; } = ModifiedType.Modified;
 
             [Description("Options")]
             [YamlMember(Order = 1401)] public bool IsMonitor { get; set; } = false;
@@ -466,27 +468,42 @@ namespace yt_dlp_gui.Views {
                         if (decimal.TryParse(d[5], out decimal d_speed)) s.Speed = d_speed;
                         if (decimal.TryParse(d[6], out decimal d_elapsed)) s.Elapsed = d_elapsed;
 
-                        UpdatePersent(s.Persent);
-
-                        if (Data.DNStatus_Infos.ContainsKey("Downloader") && Data.DNStatus_Infos["Downloader"] == App.Lang.Status.Native) {
-                            Data.DNStatus_Infos["Downloaded"] = Util.GetAutoUnit((long)Data.DNStatus_Video.Downloaded + (long)Data.DNStatus_Audio.Downloaded);
-                            Data.DNStatus_Infos["Total"] = Util.GetAutoUnit((long)Data.DNStatus_Video.Total + (long)Data.DNStatus_Audio.Total);
-                            Data.DNStatus_Infos["Speed"] = Util.GetAutoUnit((long)Data.DNStatus_Video.Speed + (long)Data.DNStatus_Audio.Speed);
-                            Data.DNStatus_Infos["Elapsed"] = Util.SecToStr(Data.DNStatus_Video.Elapsed + Data.DNStatus_Audio.Elapsed);
-                            Data.DNStatus_Infos["Status"] = App.Lang.Status.Downloading;
+                        if (Data.LetYtDlpMux) {
+                            Data.VideoPersent = s.Persent;
+                            Data.AudioPersent = s.Persent;
+                            Data.DNStatus_Infos["Downloaded"] = Util.GetAutoUnit((long)s.Downloaded);
+                            Data.DNStatus_Infos["Total"] = Util.GetAutoUnit((long)s.Total);
+                            Data.DNStatus_Infos["Speed"] = Util.GetAutoUnit((long)s.Speed);
+                            Data.DNStatus_Infos["Elapsed"] = Util.SecToStr(s.Elapsed);
+                        } else {
+                            UpdatePersent(s.Persent);
+                            if (Data.DNStatus_Infos.ContainsKey("Downloader") && Data.DNStatus_Infos["Downloader"] == App.Lang.Status.Native) {
+                                Data.DNStatus_Infos["Downloaded"] = Util.GetAutoUnit((long)Data.DNStatus_Video.Downloaded + (long)Data.DNStatus_Audio.Downloaded);
+                                Data.DNStatus_Infos["Total"] = Util.GetAutoUnit((long)Data.DNStatus_Video.Total + (long)Data.DNStatus_Audio.Total);
+                                Data.DNStatus_Infos["Speed"] = Util.GetAutoUnit((long)Data.DNStatus_Video.Speed + (long)Data.DNStatus_Audio.Speed);
+                                Data.DNStatus_Infos["Elapsed"] = Util.SecToStr(Data.DNStatus_Video.Elapsed + Data.DNStatus_Audio.Elapsed);
+                            }
                         }
+                        Data.DNStatus_Infos["Status"] = App.Lang.Status.Downloading;
                     } else if (regAria.IsMatch(std)) {
                         // aria2
                         Data.DNStatus_Infos["Downloader"] = "aria2c";
-                        var d = Util.GetGroup(regAria, std);
-                        if (decimal.TryParse(d["persent"], out decimal o_persent)) {
-                            UpdatePersent(o_persent);
+                        var d_aria = Util.GetGroup(regAria, std); // Corrected d to d_aria
+                        if (Data.LetYtDlpMux) {
+                            if (decimal.TryParse(d_aria["persent"], out decimal o_persent_aria)) {
+                                Data.VideoPersent = o_persent_aria;
+                                Data.AudioPersent = o_persent_aria;
+                            }
+                        } else {
+                            if (decimal.TryParse(d_aria["persent"], out decimal o_persent_aria)) {
+                                UpdatePersent(o_persent_aria);
+                            }
                         }
-                        Data.DNStatus_Infos["Downloaded"] = d["downloaded"];
-                        Data.DNStatus_Infos["Total"] = d["total"];
-                        Data.DNStatus_Infos["Speed"] = d["speed"];
-                        Data.DNStatus_Infos["Elapsed"] = d.GetValueOrDefault("eta", "0s");
-                        Data.DNStatus_Infos["Connections"] = d["cn"];
+                        Data.DNStatus_Infos["Downloaded"] = d_aria["downloaded"];
+                        Data.DNStatus_Infos["Total"] = d_aria["total"]; // Corrected d to d_aria
+                        Data.DNStatus_Infos["Speed"] = d_aria["speed"]; // Corrected d to d_aria
+                        Data.DNStatus_Infos["Elapsed"] = d_aria.GetValueOrDefault("eta", "0s"); // Corrected d to d_aria
+                        Data.DNStatus_Infos["Connections"] = d_aria["cn"]; // Corrected d to d_aria
                         Data.DNStatus_Infos["Status"] = App.Lang.Status.Downloading;
                     } else if (regFF.IsMatch(std)) {
                         // ffmpeg

--- a/yt-dlp-gui/Views/Main.xaml
+++ b/yt-dlp-gui/Views/Main.xaml
@@ -604,6 +604,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
@@ -651,9 +652,12 @@
                 <!--UseAria2-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
                 <TextBlock Grid.Row="3" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Aria2}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                 <CheckBox Grid.Row="3" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.Aria2Enabled}" IsEnabled="{Binding Enable.UseAria2}" IsChecked="{Binding UseAria2}" Margin="0,2"/>
+                <!-- Let yt-dlp combine formats -->
+                <TextBlock Grid.Row="4" Text="Let yt-dlp combine formats" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                <CheckBox Grid.Row="4" Grid.Column="2" Content="Enabled" IsChecked="{Binding LetYtDlpMux}" Margin="0,2"/>
                 <!--Embeds-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="4" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Embeds}" VerticalAlignment="Top" Margin="0,3" HorizontalAlignment="Right"/>
-                <Grid Grid.Row="4" Grid.Column="2">
+                <TextBlock Grid.Row="5" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Embeds}" VerticalAlignment="Top" Margin="0,3" HorizontalAlignment="Right"/>
+                <Grid Grid.Row="5" Grid.Column="2">
                     <Grid.RowDefinitions>
                         <RowDefinition/>
                         <RowDefinition/>
@@ -665,23 +669,23 @@
                 </Grid>
                 <!--EmbedSubs-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
                 <!--
-                    <TextBlock Grid.Row="4" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedSubs}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                    <CheckBox Grid.Row="4" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedSubsEnabled}" Margin="0,2" IsChecked="{Binding EmbedSub}"/>
+                    <TextBlock Grid.Row="5" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedSubs}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <CheckBox Grid.Row="5" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedSubsEnabled}" Margin="0,2" IsChecked="{Binding EmbedSub}"/>
                     -->
                 <!--TimeRange-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <StackPanel Grid.Row="5" VerticalAlignment="Center" HorizontalAlignment="Right">
+                <StackPanel Grid.Row="6" VerticalAlignment="Center" HorizontalAlignment="Right">
                     <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRange}" HorizontalAlignment="Right"/>
                     <TextBlock FontSize="10" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRangeHits}" Foreground="Gray" HorizontalAlignment="Right"/>
                 </StackPanel>
-                <controls:TextEditor Grid.Row="5" Grid.Column="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRangeHelper}" Text="{Binding TimeRange}" 
+                <controls:TextEditor Grid.Row="6" Grid.Column="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRangeHelper}" Text="{Binding TimeRange}"
                                          Margin="0,2" EnableHyperlinks="False"/>
                 <!--LimitRate-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="6" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.LimitRate}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                <controls:TextEditor Grid.Row="6" Grid.Column="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.LimitRateHelper}" Text="{Binding LimitRate}" 
+                <TextBlock Grid.Row="7" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.LimitRate}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                <controls:TextEditor Grid.Row="7" Grid.Column="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.LimitRateHelper}" Text="{Binding LimitRate}"
                                          Margin="0,2" EnableHyperlinks="False"/>
                 <!--Modified-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="7" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Modified}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                <ComboBox Grid.Row="7" Grid.Column="2" SelectedValue="{Binding ModifiedType}" SelectedValuePath="Tag" IsEnabled="{Binding Enable.UseCookie}" HorizontalAlignment="Left">
+                <TextBlock Grid.Row="8" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Modified}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                <ComboBox Grid.Row="8" Grid.Column="2" SelectedValue="{Binding ModifiedType}" SelectedValuePath="Tag" IsEnabled="{Binding Enable.UseCookie}" HorizontalAlignment="Left">
                     <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ModifiedModified}" Tag="{x:Static m:ModifiedType.Modified}"/>
                     <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ModifiedCreated}" Tag="{x:Static m:ModifiedType.Created}"/>
                     <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ModifiedUpload}" Tag="{x:Static m:ModifiedType.Upload}"/>


### PR DESCRIPTION
This change introduces a user-configurable option to let yt-dlp handle the muxing of video and audio streams directly when a combined format (e.g., "video_id+audio_id") is used.

Key changes:

1.  **DLP.cs (Wrapper):**
    *   The `DownloadFormat` method now accepts a `letYtDlpMux` boolean parameter.
    *   If `letYtDlpMux` is true:
        *   The GUI no longer suggests an explicit `--remux-video` container.
        *   A `--print "[finalpath]%(filepath)q"` argument is added to the
            yt-dlp command to capture the exact final filename determined
            by yt-dlp.
        *   A new public property `ActualOutputFile` is populated with this path.
    *   The `Exec` method was updated to parse this special `--print` output.

2.  **UI (Main.xaml & ViewModels/Main.cs):**
    *   Added a checkbox "Let yt-dlp combine formats" in the "Advance" settings tab.
    *   This option is bound to a new `LetYtDlpMux` property in `ViewData`.
    *   The setting is persisted in the application's YAML configuration file via `GUIConfig`.

3.  **Command Logic (Views/Main.xaml.cs):**
    *   The `Download_Start_Native` method now passes the `Data.LetYtDlpMux`
        state to the `DLP.DownloadFormat` method.
    *   Post-download file handling logic now prioritizes `dlp.ActualOutputFile`
        to correctly identify the muxed file, falling back to the previous
        method if this path isn't available.

4.  **Progress Reporting (ViewModels/Main.cs - StatusReporter):**
    *   If `Data.LetYtDlpMux` is true, progress reported by yt-dlp for
        combined downloads is now reflected as overall progress for both
        video and audio UI elements (e.g., progress bars).

This enhancement allows you to leverage yt-dlp's native muxing capabilities, potentially resulting in more efficient downloads and correct container/extension selection by yt-dlp itself.