### PR TITLE
Revert: Remove 'Let yt-dlp combine formats' feature

### DIFF
--- a/yt-dlp-gui/ViewModels/Main.cs
+++ b/yt-dlp-gui/ViewModels/Main.cs
@@ -230,7 +230,6 @@ namespace yt_dlp_gui.Views {
             public ModifiedType ModifiedType { get; set; } = ModifiedType.Modified;
             public string TimeRange { get; set; } = string.Empty;
             public string LimitRate { get; set; } = string.Empty;
-            public bool LetYtDlpMux { get; set; } = false;
             public Enable Enable { get; set; } = new();
             public bool AutoSaveConfig { get; set; } = false;
             public string Html { get; set; } = string.Empty;
@@ -400,12 +399,11 @@ namespace yt_dlp_gui.Views {
             [Description("Advance")]
             [YamlMember(Order = 1301)] public string ConfigurationFile { get; set; } = string.Empty;
             [YamlMember(Order = 1302)] public bool UseAria2 { get; set; } = false;
-            [YamlMember(Order = 1303)] public bool LetYtDlpMux { get; set; } = false;
-            [YamlMember(Order = 1304)] public bool EmbedThumbnail { get; set; } = false;
-            [YamlMember(Order = 1305)] public bool EmbedChapters { get; set; } = false;
-            [YamlMember(Order = 1306)] public bool EmbedSubtitles { get; set; } = false;
-            [YamlMember(Order = 1307)] public string LimitRate { get; set; } = string.Empty;
-            [YamlMember(Order = 1308)] public ModifiedType ModifiedType { get; set; } = ModifiedType.Modified;
+            [YamlMember(Order = 1303)] public bool EmbedThumbnail { get; set; } = false;
+            [YamlMember(Order = 1304)] public bool EmbedChapters { get; set; } = false;
+            [YamlMember(Order = 1305)] public bool EmbedSubtitles { get; set; } = false;
+            [YamlMember(Order = 1306)] public string LimitRate { get; set; } = string.Empty;
+            [YamlMember(Order = 1307)] public ModifiedType ModifiedType { get; set; } = ModifiedType.Modified;
 
             [Description("Options")]
             [YamlMember(Order = 1401)] public bool IsMonitor { get; set; } = false;
@@ -468,42 +466,26 @@ namespace yt_dlp_gui.Views {
                         if (decimal.TryParse(d[5], out decimal d_speed)) s.Speed = d_speed;
                         if (decimal.TryParse(d[6], out decimal d_elapsed)) s.Elapsed = d_elapsed;
 
-                        if (Data.LetYtDlpMux) {
-                            Data.VideoPersent = s.Persent;
-                            Data.AudioPersent = s.Persent;
-                            Data.DNStatus_Infos["Downloaded"] = Util.GetAutoUnit((long)s.Downloaded);
-                            Data.DNStatus_Infos["Total"] = Util.GetAutoUnit((long)s.Total);
-                            Data.DNStatus_Infos["Speed"] = Util.GetAutoUnit((long)s.Speed);
-                            Data.DNStatus_Infos["Elapsed"] = Util.SecToStr(s.Elapsed);
-                        } else {
-                            UpdatePersent(s.Persent);
-                            if (Data.DNStatus_Infos.ContainsKey("Downloader") && Data.DNStatus_Infos["Downloader"] == App.Lang.Status.Native) {
-                                Data.DNStatus_Infos["Downloaded"] = Util.GetAutoUnit((long)Data.DNStatus_Video.Downloaded + (long)Data.DNStatus_Audio.Downloaded);
-                                Data.DNStatus_Infos["Total"] = Util.GetAutoUnit((long)Data.DNStatus_Video.Total + (long)Data.DNStatus_Audio.Total);
-                                Data.DNStatus_Infos["Speed"] = Util.GetAutoUnit((long)Data.DNStatus_Video.Speed + (long)Data.DNStatus_Audio.Speed);
-                                Data.DNStatus_Infos["Elapsed"] = Util.SecToStr(Data.DNStatus_Video.Elapsed + Data.DNStatus_Audio.Elapsed);
-                            }
+                        UpdatePersent(s.Persent);
+                        if (Data.DNStatus_Infos.ContainsKey("Downloader") && Data.DNStatus_Infos["Downloader"] == App.Lang.Status.Native) {
+                            Data.DNStatus_Infos["Downloaded"] = Util.GetAutoUnit((long)Data.DNStatus_Video.Downloaded + (long)Data.DNStatus_Audio.Downloaded);
+                            Data.DNStatus_Infos["Total"] = Util.GetAutoUnit((long)Data.DNStatus_Video.Total + (long)Data.DNStatus_Audio.Total);
+                            Data.DNStatus_Infos["Speed"] = Util.GetAutoUnit((long)Data.DNStatus_Video.Speed + (long)Data.DNStatus_Audio.Speed);
+                            Data.DNStatus_Infos["Elapsed"] = Util.SecToStr(Data.DNStatus_Video.Elapsed + Data.DNStatus_Audio.Elapsed);
                         }
                         Data.DNStatus_Infos["Status"] = App.Lang.Status.Downloading;
                     } else if (regAria.IsMatch(std)) {
                         // aria2
                         Data.DNStatus_Infos["Downloader"] = "aria2c";
-                        var d_aria = Util.GetGroup(regAria, std); // Corrected d to d_aria
-                        if (Data.LetYtDlpMux) {
-                            if (decimal.TryParse(d_aria["persent"], out decimal o_persent_aria)) {
-                                Data.VideoPersent = o_persent_aria;
-                                Data.AudioPersent = o_persent_aria;
-                            }
-                        } else {
-                            if (decimal.TryParse(d_aria["persent"], out decimal o_persent_aria)) {
-                                UpdatePersent(o_persent_aria);
-                            }
+                        var d_aria = Util.GetGroup(regAria, std);
+                        if (decimal.TryParse(d_aria["persent"], out decimal o_persent_aria)) {
+                            UpdatePersent(o_persent_aria);
                         }
                         Data.DNStatus_Infos["Downloaded"] = d_aria["downloaded"];
-                        Data.DNStatus_Infos["Total"] = d_aria["total"]; // Corrected d to d_aria
-                        Data.DNStatus_Infos["Speed"] = d_aria["speed"]; // Corrected d to d_aria
-                        Data.DNStatus_Infos["Elapsed"] = d_aria.GetValueOrDefault("eta", "0s"); // Corrected d to d_aria
-                        Data.DNStatus_Infos["Connections"] = d_aria["cn"]; // Corrected d to d_aria
+                        Data.DNStatus_Infos["Total"] = d_aria["total"];
+                        Data.DNStatus_Infos["Speed"] = d_aria["speed"];
+                        Data.DNStatus_Infos["Elapsed"] = d_aria.GetValueOrDefault("eta", "0s");
+                        Data.DNStatus_Infos["Connections"] = d_aria["cn"];
                         Data.DNStatus_Infos["Status"] = App.Lang.Status.Downloading;
                     } else if (regFF.IsMatch(std)) {
                         // ffmpeg

--- a/yt-dlp-gui/Views/Main.xaml
+++ b/yt-dlp-gui/Views/Main.xaml
@@ -604,7 +604,6 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
@@ -652,12 +651,9 @@
                 <!--UseAria2-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
                 <TextBlock Grid.Row="3" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Aria2}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                 <CheckBox Grid.Row="3" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.Aria2Enabled}" IsEnabled="{Binding Enable.UseAria2}" IsChecked="{Binding UseAria2}" Margin="0,2"/>
-                <!-- Let yt-dlp combine formats -->
-                <TextBlock Grid.Row="4" Text="Let yt-dlp combine formats" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                <CheckBox Grid.Row="4" Grid.Column="2" Content="Enabled" IsChecked="{Binding LetYtDlpMux}" Margin="0,2"/>
                 <!--Embeds-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="5" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Embeds}" VerticalAlignment="Top" Margin="0,3" HorizontalAlignment="Right"/>
-                <Grid Grid.Row="5" Grid.Column="2">
+                <TextBlock Grid.Row="4" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Embeds}" VerticalAlignment="Top" Margin="0,3" HorizontalAlignment="Right"/>
+                <Grid Grid.Row="4" Grid.Column="2">
                     <Grid.RowDefinitions>
                         <RowDefinition/>
                         <RowDefinition/>
@@ -669,23 +665,23 @@
                 </Grid>
                 <!--EmbedSubs-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
                 <!--
-                    <TextBlock Grid.Row="5" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedSubs}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                    <CheckBox Grid.Row="5" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedSubsEnabled}" Margin="0,2" IsChecked="{Binding EmbedSub}"/>
+                    <TextBlock Grid.Row="4" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedSubs}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                    <CheckBox Grid.Row="4" Grid.Column="2" Content="{Binding Source={x:Static app:App.Lang}, Path=Main.EmbedSubsEnabled}" Margin="0,2" IsChecked="{Binding EmbedSub}"/>
                     -->
                 <!--TimeRange-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <StackPanel Grid.Row="6" VerticalAlignment="Center" HorizontalAlignment="Right">
+                <StackPanel Grid.Row="5" VerticalAlignment="Center" HorizontalAlignment="Right">
                     <TextBlock Text="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRange}" HorizontalAlignment="Right"/>
                     <TextBlock FontSize="10" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRangeHits}" Foreground="Gray" HorizontalAlignment="Right"/>
                 </StackPanel>
-                <controls:TextEditor Grid.Row="6" Grid.Column="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRangeHelper}" Text="{Binding TimeRange}"
+                <controls:TextEditor Grid.Row="5" Grid.Column="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.TimeRangeHelper}" Text="{Binding TimeRange}"
                                          Margin="0,2" EnableHyperlinks="False"/>
                 <!--LimitRate-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="7" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.LimitRate}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                <controls:TextEditor Grid.Row="7" Grid.Column="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.LimitRateHelper}" Text="{Binding LimitRate}"
+                <TextBlock Grid.Row="6" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.LimitRate}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                <controls:TextEditor Grid.Row="6" Grid.Column="2" Helper="{Binding Source={x:Static app:App.Lang}, Path=Main.LimitRateHelper}" Text="{Binding LimitRate}"
                                          Margin="0,2" EnableHyperlinks="False"/>
                 <!--Modified-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ -->
-                <TextBlock Grid.Row="8" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Modified}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                <ComboBox Grid.Row="8" Grid.Column="2" SelectedValue="{Binding ModifiedType}" SelectedValuePath="Tag" IsEnabled="{Binding Enable.UseCookie}" HorizontalAlignment="Left">
+                <TextBlock Grid.Row="7" Text="{Binding Source={x:Static app:App.Lang}, Path=Main.Modified}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                <ComboBox Grid.Row="7" Grid.Column="2" SelectedValue="{Binding ModifiedType}" SelectedValuePath="Tag" IsEnabled="{Binding Enable.UseCookie}" HorizontalAlignment="Left">
                     <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ModifiedModified}" Tag="{x:Static m:ModifiedType.Modified}"/>
                     <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ModifiedCreated}" Tag="{x:Static m:ModifiedType.Created}"/>
                     <ComboBoxItem Content="{Binding Source={x:Static app:App.Lang}, Path=Main.ModifiedUpload}" Tag="{x:Static m:ModifiedType.Upload}"/>

--- a/yt-dlp-gui/Views/Main.xaml.cs
+++ b/yt-dlp-gui/Views/Main.xaml.cs
@@ -507,7 +507,7 @@ namespace yt_dlp_gui.Views {
                                 .EmbedChapters(Data.EmbedChapters)
                                 .Thumbnail(Data.SaveThumbnail, Data.TargetFile, Data.EmbedThumbnail)
                                 .Subtitle(Data.selectedSub.key, Data.TargetFile, Data.EmbedSubtitles)
-                                .DownloadFormat(vid, Data.TargetFile, Data.OriginExt, Data.LetYtDlpMux);
+                                .DownloadFormat(vid, Data.TargetFile, Data.OriginExt);
                                 break;
                         }
                         var repoter = new StatusRepoter(Data);
@@ -528,37 +528,17 @@ namespace yt_dlp_gui.Views {
 
                         //post-process
                         Dictionary<string, string> files = new Dictionary<string, string>();
-                        string mainVideoFile = null;
-
-                        if (!string.IsNullOrEmpty(dlp.ActualOutputFile) && File.Exists(dlp.ActualOutputFile)) {
-                            mainVideoFile = dlp.ActualOutputFile;
-                            if (mainVideoFile.isVideo()) { // Assuming Util.isVideo exists or create similar check based on DLPExtend
-                                files["video"] = mainVideoFile;
-                            }
-                            // Apply modification time if necessary
-                            if (Data.ModifiedType == ModifiedType.Upload) {
-                                if (DateTimeOffset.TryParseExact(Data.Video.upload_date, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTimeOffset tryDate)) {
-                                    File.SetLastWriteTimeUtc(mainVideoFile, tryDate.DateTime);
-                                }
-                            }
-                        }
-
                         foreach (string donepath in dlp.Files) {
                             if (File.Exists(donepath)) {
-                                if (donepath.isVideo() && mainVideoFile == null) { // Only if mainVideoFile not already set by ActualOutputFile
+                                if (donepath.isVideo()) {
                                     files["video"] = donepath;
-                                    mainVideoFile = donepath; // Fallback
                                 }
-                                if (donepath.isImage()) { // Assuming Util.isImage
+                                if (donepath.isImage()) {
                                     files["thumb"] = donepath;
                                 }
-
-                                // Apply modification time, ensure not to double-process mainVideoFile if already handled
                                 if (Data.ModifiedType == ModifiedType.Upload) {
-                                    if (donepath != mainVideoFile || string.IsNullOrEmpty(dlp.ActualOutputFile)) { // Process if it's an aux file, or if it's the main file AND ActualOutput was not used
-                                         if (DateTimeOffset.TryParseExact(Data.Video.upload_date, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTimeOffset tryDate)) {
-                                             File.SetLastWriteTimeUtc(donepath, tryDate.DateTime);
-                                         }
+                                    if (DateTimeOffset.TryParseExact(Data.Video.upload_date, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTimeOffset tryDate)) {
+                                        File.SetLastWriteTimeUtc(donepath, tryDate.DateTime);
                                     }
                                 }
                             }


### PR DESCRIPTION
This commit reverts the recently added feature that allowed you to choose if yt-dlp should handle video/audio muxing directly. The changes have been undone to restore the application's previous behavior based on your feedback.

Reverted changes include:
- Removal of the 'LetYtDlpMux' checkbox from the UI (Main.xaml).
- Removal of the `LetYtDlpMux` property from `ViewData` and `GUIConfig` (ViewModels/Main.cs).
- Restoration of original YamlMember ordering in `GUIConfig`.
- Reversion of `DLP.cs`:
    - `DownloadFormat` method restored to its original signature and logic, unconditionally applying `--remux-video` if target/origin extensions differ, and always adding the GUI's target path to `Files`.
    - Removed the `--no-simulate` and `--print` options that were part of the reverted feature.
    - Removed the `ActualOutputFile` property and associated parsing logic in the `Exec` method.
- Reversion of `Main.xaml.cs`:
    - `Download_Start_Native` method no longer passes a muxing flag to `DLP.DownloadFormat`.
    - Post-download file handling logic reverted to solely use `dlp.Files`.
- Reversion of `StatusReporter` in `ViewModels/Main.cs` to its original progress update logic, removing branching based on the muxing flag.

The application will now consistently use its established method for invoking yt-dlp, including potentially specifying --remux-video. The general stdout debug logging in `DLP.cs` has been retained.