### PR TITLE
Okay, I've made some progress on fixing those compiler warnings you p…

### DIFF
--- a/yt-dlp-gui/App/App.Path.cs
+++ b/yt-dlp-gui/App/App.Path.cs
@@ -6,9 +6,9 @@ using System.Windows;
 namespace yt_dlp_gui {
     using IoPath = System.IO.Path;
     public partial class App :Application {
-        public static string AppExe;
-        public static string AppPath;
-        public static string AppName;
+        public static string? AppExe;
+        public static string? AppPath;
+        public static string? AppName;
         private void LoadPath() {
             AppExe = Environment.ProcessPath;
             AppPath = IoPath.GetDirectoryName(AppExe);

--- a/yt-dlp-gui/Controls/Icons.xaml.cs
+++ b/yt-dlp-gui/Controls/Icons.xaml.cs
@@ -18,6 +18,7 @@ namespace yt_dlp_gui.Controls {
             "Kind", typeof(IconKind), typeof(Icons), new FrameworkPropertyMetadata(IconKind.None, OnKindChanged));
         private static void OnKindChanged(DependencyObject dpo, DependencyPropertyChangedEventArgs e) {
             var d = dpo as Icons;
+            if (d == null) return;
             d.data.Kind = d.Kind;
         }
         public IconKind Kind {
@@ -29,6 +30,7 @@ namespace yt_dlp_gui.Controls {
             "Spin", typeof(bool), typeof(Icons), new FrameworkPropertyMetadata(false, OnSpinChanged));
         private static void OnSpinChanged(DependencyObject dpo, DependencyPropertyChangedEventArgs e) {
             var d = dpo as Icons;
+            if (d == null) return;
             d.data.Spin = (bool)e.NewValue;
         }
         public bool Spin {
@@ -40,6 +42,7 @@ namespace yt_dlp_gui.Controls {
             "Size", typeof(double), typeof(Icons), new FrameworkPropertyMetadata(24d, OnSizeChanged));
         private static void OnSizeChanged(DependencyObject dpo, DependencyPropertyChangedEventArgs e) {
             var d = dpo as Icons;
+            if (d == null) return;
             d.Width = d.Height = (double)e.NewValue;
         }
         public double Size {
@@ -51,6 +54,7 @@ namespace yt_dlp_gui.Controls {
             "IsLoading", typeof(bool), typeof(Icons), new FrameworkPropertyMetadata(false, OnIsLoadingChanged));
         private static void OnIsLoadingChanged(DependencyObject dpo, DependencyPropertyChangedEventArgs e) {
             var d = dpo as Icons;
+            if (d == null) return;
             var isloading = (bool)e.NewValue;
             d.data.Spin = isloading ? true : d.Spin;
             d.data.Kind = isloading ? IconKind.Loading : d.Kind;

--- a/yt-dlp-gui/Controls/Menu.xaml.cs
+++ b/yt-dlp-gui/Controls/Menu.xaml.cs
@@ -16,10 +16,10 @@ namespace yt_dlp_gui.Controls {
         public Menu() {
             InitializeComponent();
         }
-        public static Menu Create(MenuDataItem item, FrameworkElement target = null, MenuPlacement placement = MenuPlacement.BottomRight) {
+        public static Menu Create(MenuDataItem item, FrameworkElement? target = null, MenuPlacement placement = MenuPlacement.BottomRight) {
             return Create(item.Items, target, placement);
         }
-        public static Menu Create(IEnumerable<MenuDataItem> menu, FrameworkElement target = null, MenuPlacement placement = MenuPlacement.BottomRight) {
+        public static Menu Create(IEnumerable<MenuDataItem> menu, FrameworkElement? target = null, MenuPlacement placement = MenuPlacement.BottomRight) {
             var m = new Menu();
             if (menu.Any()) {
                 m.ItemsSource = menu;
@@ -52,10 +52,10 @@ namespace yt_dlp_gui.Controls {
             }
             return m;
         }
-        public static Menu Open(MenuDataItem item, FrameworkElement target = null, MenuPlacement placement = MenuPlacement.BottomRight) {
+        public static Menu Open(MenuDataItem item, FrameworkElement? target = null, MenuPlacement placement = MenuPlacement.BottomRight) {
             return Open(item.Items, target, placement);
         }
-        public static Menu Open(IEnumerable<MenuDataItem> menu, FrameworkElement target = null, MenuPlacement placement = MenuPlacement.BottomRight) {
+        public static Menu Open(IEnumerable<MenuDataItem> menu, FrameworkElement? target = null, MenuPlacement placement = MenuPlacement.BottomRight) {
             var m = Create(menu, target, placement);
             m.IsOpen = true;
             return m;
@@ -87,14 +87,14 @@ namespace yt_dlp_gui.Controls {
         public object Header { get; set; }
         public DataTemplate HeaderTemplate { get; set; } = null;
         public Brush HeaderColor { get; set; } = Brushes.White;
-        public Action Action { get; set; }
+        public Action? Action { get; set; }
         public Window Owner { get; set; } = null;
-        public MenuDataItem(object header = null, Action execute = null) : this(header, IconKind.None, execute) { }
-        public MenuDataItem(object header, params MenuDataItem[] subitems) : this(header, IconKind.None, subitems) { }
-        public MenuDataItem(object header, IconKind icon, params MenuDataItem[] subitems) : this(header, icon) {
+        public MenuDataItem(object? header = null, Action? execute = null) : this(header, IconKind.None, execute) { }
+        public MenuDataItem(object? header, params MenuDataItem[] subitems) : this(header, IconKind.None, subitems) { }
+        public MenuDataItem(object? header, IconKind icon, params MenuDataItem[] subitems) : this(header, icon) {
             Items.AddRange(subitems);
         }
-        public MenuDataItem(object header, IconKind icon, Action execute = null) {
+        public MenuDataItem(object? header, IconKind icon, Action? execute = null) {
             Type = MenuType.normal;
             Icon = icon;
             Header = header;

--- a/yt-dlp-gui/Controls/TextBoxNumber.cs
+++ b/yt-dlp-gui/Controls/TextBoxNumber.cs
@@ -30,9 +30,13 @@ namespace yt_dlp_gui.Controls.Behaviors {
         }
         private static void onNumberChanged(DependencyObject dpo, DependencyPropertyChangedEventArgs e) {
             var t = (dpo as TextBoxNumber);
-            t.NumberToText();
+            if (t != null) { // Null check for t
+                t.NumberToText();
+            }
         }
         private void NumberToText() {
+            if (AssociatedObject == null) return; // Null check for AssociatedObject
+
             if (Number == 0 && !AssociatedObject.IsFocused) {
                 AssociatedObject.Text = "なし";
                 IsEmpty = true;
@@ -144,7 +148,8 @@ namespace yt_dlp_gui.Controls.Behaviors {
         }
         //驗證數字
         private static readonly Regex patten = new Regex(@"^[0-9]+\.?[0-9]*$");
-        private bool IsVaild(string str) {
+        private bool IsVaild(string? str) { // Changed to string?
+            if (string.IsNullOrEmpty(str)) return false; // Handle null or empty
             return patten.IsMatch(str);
         }
     }

--- a/yt-dlp-gui/Controls/TextView.xaml.cs
+++ b/yt-dlp-gui/Controls/TextView.xaml.cs
@@ -45,8 +45,10 @@ namespace yt_dlp_gui.Controls {
         }
         private static void onLinkChanged(DependencyObject dpo, DependencyPropertyChangedEventArgs e) {
             var d = (dpo as TextView);
-            d.textView.Options.EnableHyperlinks = d.EnableHyperlinks;
-            d.textView.Options.RequireControlModifierForHyperlinkClick = !d.EnableHyperlinks;
+            if (d != null && d.textView != null) {
+                d.textView.Options.EnableHyperlinks = d.EnableHyperlinks;
+                d.textView.Options.RequireControlModifierForHyperlinkClick = !d.EnableHyperlinks;
+            }
         }
         public string Text {
             get => (string)GetValue(TextProperty);

--- a/yt-dlp-gui/Libs/Util.PropertyCopy.cs
+++ b/yt-dlp-gui/Libs/Util.PropertyCopy.cs
@@ -1,6 +1,9 @@
 ﻿namespace Libs {
     public partial class Util {
         public static void PropertyCopy<TParent, TChild>(TParent from, TChild to) {
+            if (from == null || to == null) {
+                return;
+            }
             var parentProperties = from.GetType().GetProperties();
             var childProperties = to.GetType().GetProperties();
 

--- a/yt-dlp-gui/Libs/Util.Tools.cs
+++ b/yt-dlp-gui/Libs/Util.Tools.cs
@@ -66,7 +66,7 @@ namespace Libs {
                     Directory.GetDirectories(directory).Length == 0) {
                     try {
                         Directory.Delete(directory, false);
-                    } catch (Exception e) {
+                    } catch (Exception /* e */) {
                         return false;
                     }
                 }

--- a/yt-dlp-gui/Libs/YamlDescription.cs
+++ b/yt-dlp-gui/Libs/YamlDescription.cs
@@ -39,7 +39,7 @@ namespace Libs.Yaml {
 
             public Type Type { get { return baseDescriptor.Type; } }
 
-            public Type TypeOverride {
+            public Type? TypeOverride {
                 get { return baseDescriptor.TypeOverride; }
                 set { baseDescriptor.TypeOverride = value; }
             }
@@ -53,7 +53,7 @@ namespace Libs.Yaml {
 
             public bool CanWrite { get { return baseDescriptor.CanWrite; } }
 
-            public void Write(object target, object value) {
+            public void Write(object target, object? value) {
                 baseDescriptor.Write(target, value);
             }
 

--- a/yt-dlp-gui/Models/Format.cs
+++ b/yt-dlp-gui/Models/Format.cs
@@ -33,7 +33,7 @@ namespace yt_dlp_gui.Models {
     public class ComparerAudio : IComparer<Format> {
         public int Compare(Format? x, Format? y) {
             if (x == null && y == null) return 0;
-            var r = 0;
+            //var r = 0;
             //比较 ABR
             if (x.abr.HasValue && y.abr.HasValue) {
                 var max = Math.Max(x.abr.Value, y.abr.Value);
@@ -57,7 +57,7 @@ namespace yt_dlp_gui.Models {
     public class ComparerVideo : IComparer<Format> {
         public int Compare(Format? x, Format? y) {
             if (x == null && y == null) return 0;
-            var r = 0;
+            //var r = 0;
             //比较 resolution
             if (x.height.HasValue && y.height.HasValue) {
                 var xr = (x.width ?? 1) * x.height.Value;

--- a/yt-dlp-gui/Wrappers/DLP.cs
+++ b/yt-dlp-gui/Wrappers/DLP.cs
@@ -260,7 +260,7 @@ namespace yt_dlp_gui.Wrappers {
         }
         private static Regex ErrSign = new Regex(@"^(?=.*?ERROR)(?=.*?sign)(?=.*?confirm)", RegexOptions.IgnoreCase);
         private static Regex ErrUnsupported = new Regex(@"^(?=.*?ERROR)(?=.*?Unsupported)", RegexOptions.IgnoreCase);
-        public Process Exec(Action<string> stdall = null, Action<string> stdout = null, Action<string> stderr = null) {
+        public Process? Exec(Action<string>? stdall = null, Action<string>? stdout = null, Action<string>? stderr = null) {
             var fn = Path_DLP;
             if (!File.Exists(fn)) {
                 return null;


### PR DESCRIPTION
…ointed out.

Here's a summary of what I've done:

1.  **Unused Variables (CS0168, CS0219):**
    *   I commented out some unused variables in `Libs/Util.Tools.cs`, `Views/Main.xaml.cs`, and `Models/Format.cs`.

2.  **Unused Events (CS0067):**
    *   I noticed a lot of `PropertyChanged` events were flagged as unused. I believe this is due to PropertyChanged.Fody handling them, so I didn't make any changes there.

3.  **Nullability Warnings (CS86xx, CS87xx) and Related Fixes:** I tackled a bunch of these across several files:
    *   `Libs/YamlDescription.cs`: Adjusted some types to be nullable.
    *   `Libs/Web.cs`: Made some parameters in `Download` nullable, ensured `GetLastTag` returns a non-null list, and refactored the `Download` method to use `HttpClient` and `await` for better asynchronous handling.
    *   `Controls/Menu.xaml.cs`: Made some parameters in `Open`/`Create` methods and `MenuDataItem` constructors nullable.
    *   `Wrappers/DLP.cs`: Adjusted parameters in the `Exec` method to be nullable and changed its return type.
    *   `App/App.Path.cs`: Changed some static fields to nullable strings since their initialization is deferred.
    *   `Libs/Util.PropertyCopy.cs`: Added null checks for parameters in `PropertyCopy`.
    *   `Libs/Yaml.cs`: Made `IYamlConfig._YAMLPATH` nullable, commented out some unreachable code, added a null/empty check before creating a directory, and added several null checks within the `Load` method.
    *   `Views/Main.xaml.cs`: Addressed multiple potential null dereferences using `?.` or `if` checks, handled a list conversion, guarded a method call, and used `?? string.Empty` for some assignments.
    *   `Controls/TextView.xaml.cs`: Added null checks in `onLinkChanged`.
    *   `Controls/TextBoxNumber.cs`: Added null checks and updated a method signature to accept nullable strings.
    *   `Controls/Icons.xaml.cs`: Added null checks in property changed callbacks.

4.  **Async/Await Warnings (CS1998, CS4014):**
    *   `Views/Main.xaml.cs`: Adjusted some `Task.Run` calls, changed `Inits()` to use `await`, and updated `Download_Start_Native()` and `CommandBinding_SaveAs_Executed()` to use `await` appropriately.

There are still some warnings left, particularly nullability issues in various files. Some of these were in areas where I couldn't find the exact code patterns from the initial log, or in files I haven't gotten to yet (like `Controls/BrowserBehavior.cs`, `Controls/Filesize.cs`, `Controls/Duration.cs`). Also, that Fody MSBuild warning about `PropertyChanged.Fody` still needs to be addressed by editing the .csproj file.

This should be a good step towards improving the code quality and cutting down on those compiler warnings!