### PR TITLE
Fix: Address compiler warnings and syntax errors in Main.xaml.cs

### DIFF
--- a/yt-dlp-gui/Views/Main.xaml.cs
+++ b/yt-dlp-gui/Views/Main.xaml.cs
@@ -641,10 +641,10 @@ namespace yt_dlp_gui.Views {
             dialog.Filter = $"{App.Lang.Files.image}|*.jpg;*.webp";
             dialog.FileName = Path.ChangeExtension(OrigFileName, ".jpg");
             if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK) {
-                DownloadThumbnail(dialog.FileName);
+                await DownloadThumbnail(dialog.FileName); // Await the async method
             }
         }
-        private void DownloadThumbnail(string toFile) {
+        private async Task DownloadThumbnail(string toFile) { // Make method async Task
             var origExt = Path.GetExtension(Data.Thumbnail);
             var origin = Path.ChangeExtension(Data.TargetFile, origExt);
             //var target = Path.ChangeExtension(Data.TargetFile, ".jpg");
@@ -652,7 +652,7 @@ namespace yt_dlp_gui.Views {
             var progress = new Progress<double>(percentage => {
                 Debug.Write($"\rDownloading... {percentage:0.00}%");
             });
-            await Web.Download(Data.Thumbnail, origin, progress, Data.ProxyEnabled ? Data.ProxyUrl : null); // CS1998: Await async Web.Download
+            await Web.Download(Data.Thumbnail, origin, progress, Data.ProxyEnabled ? Data.ProxyUrl : null);
             //convert to target ext
             if (Path.GetExtension(origin).ToLower() != Path.GetExtension(target)) {
                 FFMPEG.DownloadUrl(origin, target);


### PR DESCRIPTION
I've addressed a range of compiler warnings, focusing on nullability, async/await patterns, and unused variables. I also corrected syntax errors (CS0106, CS1513) previously reported in `Views/Main.xaml.cs`, which were likely due to structural issues introduced during prior refactoring of async code.

Key Changes:

1.  Syntax Error Corrections (CS0106, CS1513) in `Views/Main.xaml.cs`:
    - I reviewed and corrected the structure of the `Download_Start_Native` method, particularly the `try...finally` block around the `await Task.Run(...)` call. This restructuring should resolve the reported 'invalid private modifier' and 'missing }' errors.

2.  Async/Await Warning Fixes (CS1998, CS4014) in `Views/Main.xaml.cs`:
    - `Main()` constructor: I changed `Task.Run(Inits)` to `_ = Task.Run(Inits)`.
    - `Inits()`: I changed to `await Web.GetLastTag()`.
    - `Analyze_Start()`: I changed `Task.Run(...)` to `_ = Task.Run(...)`.
    - `Download_Start_Native()`: I ensured the main `Task.Run` is `await`ed and `Data.IsDownload = false` is in a `finally` block.
    - `CommandBinding_SaveAs_Executed()`: I changed to `await DownloadThumbnail(...)`.
    - `DownloadThumbnail()`: I changed signature to `async Task` and used `await Web.Download(...)`.

3.  Addressed Unused Variables (CS0168, CS0219) across multiple files:
    - I commented out unused 'e' in `Libs/Util.Tools.cs`.
    - I commented out unused 'ex' in `Views/Main.xaml.cs`.
    - I commented out unused 'r' variables in `Models/Format.cs`.

4.  Addressed Nullability Warnings (CS86xx, CS87xx) in several files:
    - `Libs/YamlDescription.cs`: I made parameters/properties nullable (e.g., `container`, `value`, `TypeOverride`).
    - `Libs/Web.cs`: I made `Download` method parameters nullable; ensured `GetLastTag` returns non-null list.
    - `Controls/Menu.xaml.cs`: I made `FrameworkElement target` and various `MenuDataItem` constructor parameters nullable.
    - `Wrappers/DLP.cs`: I made `Exec` parameters and return type nullable.
    - `App/App.Path.cs`: I made static path fields nullable.
    - `Libs/Util.PropertyCopy.cs`: I added null checks for parameters.
    - `Libs/Yaml.cs`: I made `_YAMLPATH` nullable; guarded `CreateDirectory`; handled nulls in `Load` extension method.
    - `Controls/TextView.xaml.cs`: I added null checks.
    - `Controls/TextBoxNumber.cs`: I added null checks and made `IsVaild` parameter nullable.
    - `Controls/Icons.xaml.cs`: I added null checks in property changed callbacks.

    (Note: Some nullability warnings from the initial comprehensive log
    might persist if the exact code patterns were not found in the files
    as I read them, or if they are in files not yet
    processed in this session. You provided an updated log which I
    used as the primary source for these fixes.)

5.  Addressed Unreachable Code (CS0162):
    - I commented out unreachable code in `Libs/Yaml.cs`.

6.  Unused Events (CS0067 - PropertyChanged):
    - No code changes made, as these are considered benign due to your project's use of PropertyChanged.Fody.

This set of changes aims to significantly reduce compiler warnings and fix the critical build errors. Further build logs will confirm the resolution of these issues and guide any remaining warning cleanup.