### PR TITLE
I've addressed the C# compiler errors in Views/Main.xaml.cs.

### DIFF
--- a/yt-dlp-gui/Views/Main.xaml.cs
+++ b/yt-dlp-gui/Views/Main.xaml.cs
@@ -711,7 +711,7 @@ namespace yt_dlp_gui.Views {
             Data.Width = Width;
             Data.Height = Height;
         }
-        private void ComboBox_TextChanged(object sender, TextChangedEventArgs e) {
+        void ComboBox_TextChanged(object sender, TextChangedEventArgs e) {
             var combo = sender as System.Windows.Controls.ComboBox;
             if (combo != null) {
                 if (combo.SelectedIndex == -1) {
@@ -792,7 +792,7 @@ namespace yt_dlp_gui.Views {
 
             // 利用反射機制查詢 Lang 物件是否包含指定的 key 屬性
             var Lang = App.Lang.Status;
-            var propertyInfo = Lang.GetType().GetProperty(key, BindingFlags.IgnoreCase | BindingFlags.Public | BindingF
+            var propertyInfo = Lang.GetType().GetProperty(key, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
             // 如果 Lang 物件不包含指定的 key 屬性，則返回空字串
             if (propertyInfo == null)
                 return key;


### PR DESCRIPTION
I corrected several syntax issues that were causing build failures:
- I removed an invalid 'private' modifier from an event handler (CS0106).
- I addressed errors CS1026 (')' expected) and CS1002 (';' expected) by completing an incomplete BindingFlags statement in the LanguageConverter.Convert method.
- My investigation for a reported missing curly brace (CS1513) did not find a specific missing brace; this suggests it might have been a cascading error from the BindingFlags issue.

These changes should resolve the reported build errors.