### PR TITLE
Here's the rewritten message:

### DIFF
--- a/yt-dlp-gui/Controls/Filesize.cs
+++ b/yt-dlp-gui/Controls/Filesize.cs
@@ -16,6 +16,16 @@ namespace yt_dlp_gui.Controls {
         public static readonly DependencyProperty UnitProperty
             = DependencyProperty.RegisterAttached("Unit", typeof(FilesizeUnit), typeof(Filesize),
                 new FrameworkPropertyMetadata(FilesizeUnit.Auto, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, BytesPropertyChanged));
+
+    public static readonly DependencyProperty IsApproximateProperty
+        = DependencyProperty.RegisterAttached("IsApproximate", typeof(bool), typeof(Filesize),
+            new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, BytesPropertyChanged)); // Use same callback to re-render
+
+    public static void SetIsApproximate(DependencyObject dpo, bool value)
+        => dpo.SetValue(IsApproximateProperty, value);
+
+    public static bool GetIsApproximate(DependencyObject dpo)
+        => (bool)dpo.GetValue(IsApproximateProperty);
         private static void BytesPropertyChanged(DependencyObject dpo, DependencyPropertyChangedEventArgs e) {
             var (d, v) = (dpo as TextBlock, GetBytes(dpo));
             var value = v.HasValue ? v.Value : 0;
@@ -44,6 +54,10 @@ namespace yt_dlp_gui.Controls {
                 }
             }
             var txt = adjustedSize.ToString("n" + decimalPlaces);
+            bool isApprox = GetIsApproximate(dpo);
+            if (isApprox && v.HasValue && v.Value != 0) { // Only add ~ if there's a value and it's not zero
+                txt = "~ " + txt;
+            }
             d.Inlines.Clear();
             if (!IsNegative) {
                 d.Inlines.Add(new Run(txt));

--- a/yt-dlp-gui/Models/Format.cs
+++ b/yt-dlp-gui/Models/Format.cs
@@ -9,6 +9,8 @@ namespace yt_dlp_gui.Models {
         public event PropertyChangedEventHandler? PropertyChanged;
         public decimal? asr { get; set; } = null;
         public long? filesize { get; set; } = null; //bytes
+        public long? filesize_approx { get; set; } = null;
+        public bool isFilesizeApprox { get; set; } = false;
         public string format_id { get; set; } = string.Empty;
         public string format_note { get; set; } = "";
         public decimal? fps { get; set; } = null;
@@ -90,6 +92,14 @@ namespace yt_dlp_gui.Models {
     public static class ExtensionFormat {
         public static void LoadFromVideo(this ConcurrentObservableCollection<Format> source, List<Format> from) { //, Video from
             foreach (var row in from) { //from.formats
+                if (row.filesize_approx.HasValue) {
+                    row.filesize = row.filesize_approx.Value; // Use approximate filesize if available
+                    row.isFilesizeApprox = true;
+                } else {
+                    // If filesize_approx is not present, filesize already holds the exact value (or null) from JSON.
+                    // isFilesizeApprox remains false (its default).
+                    row.isFilesizeApprox = false;
+                }
                 //分类
                 if (row.vcodec != "none" && row.acodec != "none") {
                     row.type = FormatType.package;

--- a/yt-dlp-gui/Views/Main.xaml
+++ b/yt-dlp-gui/Views/Main.xaml
@@ -387,7 +387,7 @@
                                         <TextBlock FontSize="10" Grid.Column="4" HorizontalAlignment="Center" Text="{Binding tbr, StringFormat={}{0}k, TargetNullValue=N/A}"/>
                                         <TextBlock FontSize="10" Grid.Column="5" Text="{Binding video_ext}"/>
                                         <TextBlock FontSize="10" Grid.Column="6" Text="{Binding vcodec}"/>
-                                        <TextBlock FontSize="10" Grid.Column="7" HorizontalAlignment="Right" controls:Filesize.Bytes="{Binding filesize}"/>
+                                        <TextBlock FontSize="10" Grid.Column="7" HorizontalAlignment="Right" controls:Filesize.Bytes="{Binding filesize}" controls:Filesize.IsApproximate="{Binding isFilesizeApprox}"/>
                                     </Grid>
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
@@ -471,7 +471,7 @@
                                         <TextBlock FontSize="10" Grid.Column="2" HorizontalAlignment="Center" Text="{Binding tbr, StringFormat={}{0}k, TargetNullValue=N/A}"/>
                                         <TextBlock FontSize="10" Grid.Column="3" Text="{Binding audio_ext}"/>
                                         <TextBlock FontSize="10" Grid.Column="4" Text="{Binding acodec}"/>
-                                        <TextBlock FontSize="10" Grid.Column="5" HorizontalAlignment="Right" controls:Filesize.Bytes="{Binding filesize}"/>
+                                        <TextBlock FontSize="10" Grid.Column="5" HorizontalAlignment="Right" controls:Filesize.Bytes="{Binding filesize}" controls:Filesize.IsApproximate="{Binding isFilesizeApprox}"/>
                                     </Grid>
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>


### PR DESCRIPTION
Feat: Display approximate filesize indicator (~) in GUI

This commit implements the display of the '~' character prefix for filesizes that are approximate, as indicated by yt-dlp.

Changes include:

1.  **Model Update (`Format.cs`):**
    - Added `filesize_approx` (long?) and `isFilesizeApprox` (bool) properties to the `Format` class.
    - Modified `ExtensionFormat.LoadFromVideo` to prioritize `filesize_approx` from the JSON data if available, setting `isFilesizeApprox` accordingly. The final value is stored in the main `filesize` property.

2.  **Control Enhancement (`Filesize.cs`):**
    - Added an `IsApproximate` (bool) attached dependency property to the `Filesize` static class.
    - Updated the `BytesPropertyChanged` logic to prepend "~ " to the formatted filesize string if `IsApproximate` is true and the filesize is non-zero.

3.  **UI Binding Update (`Main.xaml`):**
    - Bound the `controls:Filesize.IsApproximate` property to the `isFilesizeApprox` property of the `Format` data model in both video and audio format list templates.

This ensures that you can now visually distinguish between exact and approximate filesizes in the format lists, matching the information provided by yt-dlp's command-line output.