### PR TITLE
Fix: Correct filesize display in format lists

### DIFF
--- a/yt-dlp-gui/Models/Format.cs
+++ b/yt-dlp-gui/Models/Format.cs
@@ -96,21 +96,19 @@ namespace yt_dlp_gui.Models {
                 // 'row.filesize' and 'row.filesize_approx' are assumed to have been populated
                 // by the JSON deserializer if the corresponding fields were in the JSON.
 
-                long? exact_size_from_json = row.filesize;
-                long? approx_size_from_json = row.filesize_approx;
+                long? exact_size_from_json = row.filesize; // Value as read from JSON
+                long? approx_size_from_json = row.filesize_approx; // Value as read from JSON
 
-                if (approx_size_from_json.HasValue && approx_size_from_json.Value > 0) {
-                    // A positive approximate filesize is available. This is the definitive source.
-                    row.filesize = approx_size_from_json.Value;
-                    row.isFilesizeApprox = true;
-                } else if (exact_size_from_json.HasValue) {
-                    // No valid (positive) approximation was found, but an exact filesize is available.
-                    // (This also handles the case where approx_size_from_json might have been present but <= 0)
-                    // Ensure 'row.filesize' reflects this exact value from original JSON deserialization.
+                if (exact_size_from_json.HasValue && exact_size_from_json.Value > 0) {
+                    // Prioritize exact filesize if available and positive
                     row.filesize = exact_size_from_json.Value;
                     row.isFilesizeApprox = false;
+                } else if (approx_size_from_json.HasValue && approx_size_from_json.Value > 0) {
+                    // Use approximate filesize if exact is not available/positive, and approx is available/positive
+                    row.filesize = approx_size_from_json.Value;
+                    row.isFilesizeApprox = true;
                 } else {
-                    // Neither a positive approximate filesize nor an exact filesize is available from JSON.
+                    // Neither is available or positive
                     row.filesize = null;
                     row.isFilesizeApprox = false;
                 }


### PR DESCRIPTION
The logic for determining and displaying file sizes for video and audio formats has been updated:

1. Prioritize exact file sizes: If a format provides an exact filesize, this value is now always used, and it will be displayed without the '~' prefix.
2. Use approximate if exact is unavailable: If an exact filesize is not available but an approximate filesize is, the approximate value will be used and displayed with the '~' prefix.
3. Handles missing sizes: If neither exact nor approximate filesize is available, it's treated as an unknown size (typically displayed as 0.00 B).

This resolves issues where:
- Approximate sizes were incorrectly shown with '~' even if an exact size was available (e.g. "line 337 showing ~671.17MB" should be "671.17MB").
- Filesizes were not shown for formats where only an approximate size was available (e.g. "line 628 ... filesize is not shown" should be "~422.11MB").

The change modifies the `LoadFromVideo` method in `yt-dlp-gui/Models/Format.cs` to correctly set the `filesize` and `isFilesizeApprox` properties on the `Format` object. The existing UI bindings and controls then use these properties to render the display correctly.