### PR TITLE
Fix: Correct filesize display and save raw JSON output

### DIFF
--- a/yt-dlp-gui/Models/Format.cs
+++ b/yt-dlp-gui/Models/Format.cs
@@ -1,6 +1,7 @@
 ﻿using Swordfish.NET.Collections;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.ComponentModel;
 using Newtonsoft.Json; // Added for JsonConverter attribute
 
@@ -33,6 +34,25 @@ namespace yt_dlp_gui.Models {
         public string format { get; set; } = string.Empty;
         public string resolution { get; set; } = string.Empty;
         public string info { get; set; } = string.Empty;
+
+        private string ConvertBytesToHumanReadable(long bytes) {
+            if (bytes == 0) return "0 B";
+            long k = 1024;
+            string[] sizes = { "B", "KB", "MB", "GB", "TB" };
+            int i = (int)Math.Floor(Math.Log(bytes) / Math.Log(k));
+            double size = bytes / Math.Pow(k, i);
+            return string.Format(CultureInfo.InvariantCulture, "{0:0.00}{1}", size, sizes[i]);
+        }
+
+        public string FilesizeDisplayString {
+            get {
+                if (filesize.HasValue) {
+                    string sizeStr = ConvertBytesToHumanReadable(filesize.Value);
+                    return isFilesizeApprox ? $"~{sizeStr}" : sizeStr;
+                }
+                return "N/A";
+            }
+        }
     }
     public class ComparerAudio : IComparer<Format> {
         public int Compare(Format? x, Format? y) {

--- a/yt-dlp-gui/Views/Main.xaml
+++ b/yt-dlp-gui/Views/Main.xaml
@@ -387,7 +387,7 @@
                                         <TextBlock FontSize="10" Grid.Column="4" HorizontalAlignment="Center" Text="{Binding tbr, StringFormat={}{0}k, TargetNullValue=N/A}"/>
                                         <TextBlock FontSize="10" Grid.Column="5" Text="{Binding video_ext}"/>
                                         <TextBlock FontSize="10" Grid.Column="6" Text="{Binding vcodec}"/>
-                                        <TextBlock FontSize="10" Grid.Column="7" HorizontalAlignment="Right" controls:Filesize.Bytes="{Binding filesize}" controls:Filesize.IsApproximate="{Binding isFilesizeApprox}"/>
+                                        <TextBlock FontSize="10" Grid.Column="7" HorizontalAlignment="Right" Text="{Binding FilesizeDisplayString}"/>
                                     </Grid>
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
@@ -471,7 +471,7 @@
                                         <TextBlock FontSize="10" Grid.Column="2" HorizontalAlignment="Center" Text="{Binding tbr, StringFormat={}{0}k, TargetNullValue=N/A}"/>
                                         <TextBlock FontSize="10" Grid.Column="3" Text="{Binding audio_ext}"/>
                                         <TextBlock FontSize="10" Grid.Column="4" Text="{Binding acodec}"/>
-                                        <TextBlock FontSize="10" Grid.Column="5" HorizontalAlignment="Right" controls:Filesize.Bytes="{Binding filesize}" controls:Filesize.IsApproximate="{Binding isFilesizeApprox}"/>
+                                        <TextBlock FontSize="10" Grid.Column="5" HorizontalAlignment="Right" Text="{Binding FilesizeDisplayString}"/>
                                     </Grid>
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>

--- a/yt-dlp-gui/Views/Main.xaml.cs
+++ b/yt-dlp-gui/Views/Main.xaml.cs
@@ -306,6 +306,22 @@ namespace yt_dlp_gui.Views {
                     NullValueHandling = NullValueHandling.Ignore
                 });
 
+                // Save raw JSON
+                if (Data.Video != null) {
+                    string jsonDumpsPath = Path.Combine(App.AppPath, "JsonDumps");
+                    Directory.CreateDirectory(jsonDumpsPath);
+                    string videoTitle = Data.Video?.title ?? "UnknownVideo";
+                    string invalidCharsRegex = string.Format("[{0}]", Regex.Escape(new string(Path.GetInvalidFileNameChars())));
+                    string sanitizedTitle = Regex.Replace(videoTitle, invalidCharsRegex, "_");
+                    string timestamp = DateTime.Now.ToString("yyyyMMddHHmmss");
+                    string jsonFilePath = Path.Combine(jsonDumpsPath, $"{sanitizedTitle}_{timestamp}.json");
+                    try {
+                        File.WriteAllText(jsonFilePath, std);
+                    } catch (Exception ex) {
+                        Debug.WriteLine($"Error saving JSON dump: {ex.Message}");
+                    }
+                }
+
                 //Reading Chapters
                 {
                     Data.Chapters.Clear();


### PR DESCRIPTION
This commit addresses two issues:

1. Filesize Display:
   - Modified the `Format` class to include a `FilesizeDisplayString` property. This property formats the filesize (long?) into a human-readable string (e.g., "422.11MB") and prepends a tilde (~) if the filesize is approximate (based on the `isFilesizeApprox` property). If the filesize is not available, "N/A" is displayed.
   - Updated the XAML bindings in `Main.xaml` for the video and audio format ComboBoxes to use this new `FilesizeDisplayString` property. This ensures that filesizes are displayed correctly, with tildes for approximate values as per the issue description (e.g., "~422.11MB" or "671.17MB").

2. Save JSON Output:
   - Enhanced the `GetInfo()` method in `Main.xaml.cs` to save the raw JSON string received from `yt-dlp` during video analysis.
   - The JSON data is saved to a file in a new `JsonDumps` subdirectory within the application's path.
   - Filenames are generated using the sanitized video title and a timestamp (e.g., `VideoTitle_yyyyMMddHHmmss.json`) to ensure uniqueness.

These changes improve the accuracy of information presented to you and provide a valuable debugging/development aid by persisting the raw `yt-dlp` output.