### PR TITLE
Fix: Resolve NETSDK1022 duplicate Compile items in .csproj

### DIFF
--- a/yt-dlp-gui/yt-dlp-gui.csproj
+++ b/yt-dlp-gui/yt-dlp-gui.csproj
@@ -56,9 +56,4 @@
     <PackageReference Include="YamlDotNet" Version="13.0.2" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="Libs\FormatFOutputParser.cs" />
-    <Compile Include="Libs\SizeStringConverter.cs" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
I've removed the explicit <Compile> entries for:
- Libs\FormatFOutputParser.cs
- Libs\SizeStringConverter.cs

These files are automatically included by the .NET SDK's default globbing behavior. Explicitly listing them caused a NETSDK1022 build error due to duplicate compilation items.

This change ensures your project builds correctly by relying on the SDK's implicit inclusion of these .cs files.