### PR TITLE
Fix: Correct CS1012 syntax error in FormatFOutputParser.cs

### DIFF
--- a/yt-dlp-gui/Libs/FormatFOutputParser.cs
+++ b/yt-dlp-gui/Libs/FormatFOutputParser.cs
@@ -38,7 +38,7 @@ namespace yt_dlp_gui.Libs {
                 return idToFilesizeMap;
             }
 
-            string[] lines = fOutput.Split(new[] { '\r\n', '\r', '\n' }, System.StringSplitOptions.None);
+            string[] lines = fOutput.Split(new[] { "\r\n", "\r", "\n" }, System.StringSplitOptions.None);
 
             int headerLineIndex = -1;
             int filesizeColumnStartIndex = -1;


### PR DESCRIPTION
Corrects a C# syntax error (CS1012: Too many characters in character literal) in `FormatFOutputParser.cs`.

The `string.Split` method was incorrectly using a character literal `'\r\n'` for a multi-character newline sequence. This has been changed to the correct string literal `"\r\n"`.

This fixes the build failure caused by the syntax error.