### PR TITLE
Fix: Correct filesize display truncation and units

### DIFF
--- a/yt-dlp-gui/Models/Format.cs
+++ b/yt-dlp-gui/Models/Format.cs
@@ -64,7 +64,7 @@ namespace yt_dlp_gui.Models {
         private string ConvertBytesToHumanReadable(long bytes) {
             if (bytes == 0) return "0 B";
             long k = 1024;
-            string[] sizes = { "B", "KB", "MB", "GB", "TB" };
+            string[] sizes = { "B", "KiB", "MiB", "GiB", "TiB" };
             int i = (int)Math.Floor(Math.Log(bytes) / Math.Log(k));
             double size = bytes / Math.Pow(k, i);
             return string.Format(CultureInfo.InvariantCulture, "{0:0.00}{1}", size, sizes[i]);

--- a/yt-dlp-gui/Views/Main.xaml
+++ b/yt-dlp-gui/Views/Main.xaml
@@ -367,7 +367,7 @@
                                             <ColumnDefinition SharedSizeGroup="S_TBR_V" /> <!-- NEW: TBR -->
                                             <ColumnDefinition SharedSizeGroup="S4_V" />    <!-- Video Ext -->
                                             <ColumnDefinition SharedSizeGroup="S5_V" />    <!-- VCodec -->
-                                            <ColumnDefinition SharedSizeGroup="S6_V" />    <!-- Filesize -->
+                                            <ColumnDefinition SharedSizeGroup="S6_V" MinWidth="90" />    <!-- Filesize -->
                                         </Grid.ColumnDefinitions>
                                         <controls:Icons Size="14">
                                             <controls:Icons.Style>
@@ -453,7 +453,7 @@
                                             <ColumnDefinition SharedSizeGroup="S_TBR_A" /> <!-- NEW: TBR -->
                                             <ColumnDefinition SharedSizeGroup="S4_A" />    <!-- Audio Ext -->
                                             <ColumnDefinition SharedSizeGroup="S5_A" />    <!-- ACodec -->
-                                            <ColumnDefinition SharedSizeGroup="S6_A" />    <!-- Filesize -->
+                                            <ColumnDefinition SharedSizeGroup="S6_A" MinWidth="90" />    <!-- Filesize -->
                                         </Grid.ColumnDefinitions>
                                         <controls:Icons Size="14">
                                             <controls:Icons.Style>


### PR DESCRIPTION
This commit addresses issues with how filesizes were displayed in the format selection lists:

1.  **Unit Correction (`Format.cs`):**
    *   Modified the `ConvertBytesToHumanReadable` method in `Format.cs`
        to use "KiB", "MiB", "GiB", "TiB" as units for filesize display.
        This aligns the displayed units with the base 1024 calculations
        being performed and common conventions (e.g., `yt-dlp -F` output).

2.  **Filesize Truncation (`Main.xaml`):**
    *   Adjusted the XAML for the video and audio format ComboBox item
        templates in `Main.xaml`.
    *   Added `MinWidth="90"` to the `ColumnDefinition` elements
        responsible for displaying the filesize string. This ensures
        sufficient space is allocated to prevent truncation of longer
        filesize strings (e.g., "~1234.56MiB").

These changes improve the accuracy and clarity of the filesize information presented to you.