### PR TITLE
Fix: Add missing using System directive to FormatFOutputParser.cs

### DIFF
--- a/yt-dlp-gui/Libs/FormatFOutputParser.cs
+++ b/yt-dlp-gui/Libs/FormatFOutputParser.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Diagnostics; // For Debug.WriteLine


### PR DESCRIPTION
Adds the `using System;` directive to `Libs/FormatFOutputParser.cs`. This was missing and caused CS0103 build errors because types from the System namespace (e.g., `Math`, `StringComparison`) were used without being fully qualified or having the namespace imported.

This change resolves these compilation errors.