### PR TITLE
feat: Upload built executable to GitHub Release

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,8 +1,8 @@
 name: yt-dlp GUI CI Builder
 
 on:
-  push:
-    branches: [ "master" ]
+  release:
+    types: [created]
 
 jobs:
 
@@ -27,6 +27,17 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.400
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      with:
+        tag_name: ${{ github.ref_name }}
+        release_name: Release ${{ github.ref_name }}
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
@@ -61,6 +72,16 @@ jobs:
           exit 0
         }
       shell: pwsh
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./publish_output/yt-dlp-gui.exe
+        asset_name: yt-dlp-gui.exe
+        asset_content_type: application/octet-stream
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v4.3.4


### PR DESCRIPTION
I modified the GitHub Actions workflow to support uploading the built application executable as a release asset.

Key changes:
- I changed the workflow trigger from 'on: push' to 'on: release: types: [created]'.
- I added a step to create a GitHub Release using 'actions/create-release@v1'. This uses the tag name from the release event.
- I added a step to upload 'yt-dlp-gui.exe' from the build output to the created release using 'actions/upload-release-asset@v1'.
- The existing workflow artifact upload is preserved for CI debugging purposes.

This change allows you to easily download the application executable from the GitHub Releases page.