### PR TITLE
feat: Implement hybrid build and release workflow

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,6 +1,8 @@
 name: yt-dlp GUI CI Builder
 
 on:
+  push:
+    branches: [ "master" ]
   release:
     types: [created]
 
@@ -31,6 +33,7 @@ jobs:
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
+      if: github.event_name == 'release'
       with:
         tag_name: ${{ github.ref_name }}
         release_name: Release ${{ github.ref_name }}
@@ -75,6 +78,7 @@ jobs:
 
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1
+      if: github.event_name == 'release'
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./publish_output/yt-dlp-gui.exe


### PR DESCRIPTION
I've updated the GitHub Actions workflow to support two scenarios:
1. On push to master: I will build the application and upload it as a workflow artifact.
2. On release creation: I will build the application, upload it as a workflow artifact, create a GitHub Release, and upload the built executable as a release asset.

Changes I made:
- Modified the workflow trigger to include both `push: branches: [master]` and `release: types: [created]`.
- Added `if: github.event_name == 'release'` condition to the "Create Release" step.
- Added `if: github.event_name == 'release'` condition to the "Upload Release Asset" step.
- Ensured the "Upload Build Artifact" step runs for both trigger types.

This provides flexibility for CI builds on master and formal releases with assets.