### PR TITLE
fix: Use event context for release asset upload URL

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -3,6 +3,8 @@ name: yt-dlp GUI CI Builder
 on:
   push:
     branches: [ "master" ]
+  release:
+    types: [created]
 
 jobs:
 
@@ -61,6 +63,17 @@ jobs:
           exit 0
         }
       shell: pwsh
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      if: github.event_name == 'release'
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./publish_output/yt-dlp-gui.exe
+        asset_name: yt-dlp-gui.exe
+        asset_content_type: application/octet-stream
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v4.3.4


### PR DESCRIPTION
Refactored the GitHub Actions workflow to correctly handle release asset uploads.

- Removed the 'actions/create-release@v1' step, as it caused conflicts when a release (and its tag) already existed, leading to a 'tag_name already_exists' error.
- Modified the 'Upload Release Asset' step to use `github.event.release.upload_url` directly from the release event context. This ensures that assets are uploaded to the specific release that triggered the workflow.

The workflow continues to support dual triggers:
- On push to master: Builds and uploads a workflow artifact.
- On release creation: Builds, uploads a workflow artifact, and uploads the executable as a release asset to the triggering release.